### PR TITLE
Upgrade to latest JNet version to solve crash of KNetCLI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
 
       - name: Install local file to be used within Javadoc plugin of generated POM
-        run: mvn install:install-file -DgroupId=JCOBridge -DartifactId=JCOBridge -Dversion=2.4.11 -Dpackaging=jar -Dfile=./bin/net5.0/JCOBridge.jar
+        run: mvn install:install-file -DgroupId=JCOBridge -DartifactId=JCOBridge -Dversion=2.4.12 -Dpackaging=jar -Dfile=./bin/net5.0/JCOBridge.jar
         shell: bash
 
       - name: Create Jars

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -87,7 +87,7 @@ jobs:
 
     - name: Maven preparation (step 2)
       if: matrix.language == 'java' 
-      run: mvn "install:install-file" "-DgroupId=JCOBridge" "-DartifactId=JCOBridge" "-Dversion=2.4.11" "-Dpackaging=jar" "-Dfile=./bin/net5.0/JCOBridge.jar"
+      run: mvn "install:install-file" "-DgroupId=JCOBridge" "-DartifactId=JCOBridge" "-Dversion=2.4.12" "-Dpackaging=jar" "-Dfile=./bin/net5.0/JCOBridge.jar"
 
     - if: matrix.language == 'java' 
       run: mvn --file ./src/java/knet/pom.xml --no-transfer-progress package

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -51,7 +51,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
 
       - name: Install local file to be used within Javadoc plugin of generated POM
-        run: mvn install:install-file -DgroupId=JCOBridge -DartifactId=JCOBridge -Dversion=2.4.11 -Dpackaging=jar -Dfile=./bin/net5.0/JCOBridge.jar
+        run: mvn install:install-file -DgroupId=JCOBridge -DartifactId=JCOBridge -Dversion=2.4.12 -Dpackaging=jar -Dfile=./bin/net5.0/JCOBridge.jar
         shell: bash
 
       - name: Create Jars

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
 
       - name: Install local file to be used within Javadoc plugin of generated POM
-        run: mvn install:install-file -DgroupId=JCOBridge -DartifactId=JCOBridge -Dversion=2.4.11 -Dpackaging=jar -Dfile=./bin/net5.0/JCOBridge.jar
+        run: mvn install:install-file -DgroupId=JCOBridge -DartifactId=JCOBridge -Dversion=2.4.12 -Dpackaging=jar -Dfile=./bin/net5.0/JCOBridge.jar
         shell: bash
 
       - name: Create Jars

--- a/src/java/knet/pom.xml
+++ b/src/java/knet/pom.xml
@@ -9,7 +9,7 @@
     <name>mases.knet</name>
     <description>Interface bridging implementation for Apache Kafka</description>
     <url>https://github.com/masesgroup/KNet</url>
-    <version>1.2.2.0</version>
+    <version>1.2.3.0</version>
 
     <licenses>
         <license>
@@ -175,7 +175,7 @@
                         <additionalDependency>
                             <groupId>JCOBridge</groupId>
                             <artifactId>JCOBridge</artifactId>
-                            <version>2.4.11</version>
+                            <version>2.4.12</version>
                         </additionalDependency>
                     </additionalDependencies>
                 </configuration>

--- a/src/net/KNet/KNet.csproj
+++ b/src/net/KNet/KNet.csproj
@@ -9,7 +9,7 @@
 		<Owners>MASES s.r.l.</Owners>
 		<Authors>MASES s.r.l.</Authors>
 		<Company>MASES s.r.l.</Company>
-		<Version>1.2.2.0</Version>
+		<Version>1.2.3.0</Version>
 		<Product>KNet</Product>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
@@ -54,7 +54,7 @@
     <None Include="..\Documentation\articles\usage.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MASES.JNet" Version="1.4.1">
+    <PackageReference Include="MASES.JNet" Version="1.4.2">
       <IncludeAssets>All</IncludeAssets>
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>

--- a/src/net/KNetCLI/KNetCLI.csproj
+++ b/src/net/KNetCLI/KNetCLI.csproj
@@ -10,7 +10,7 @@
     <Owners>MASES s.r.l.</Owners>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>1.2.2.0</Version>
+    <Version>1.2.3.0</Version>
     <Product>KNetCLI</Product>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>

--- a/src/net/KNetCLI/KNetCLI.nuspec
+++ b/src/net/KNetCLI/KNetCLI.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>MASES.KNetCLI</id>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <title>KNetCLI - CLI interface of KNet</title>
     <authors>MASES s.r.l.</authors>
 	<owners>MASES s.r.l.</owners>

--- a/src/net/templates/templatepack.csproj
+++ b/src/net/templates/templatepack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.2.2.0</PackageVersion>
+    <PackageVersion>1.2.3.0</PackageVersion>
     <PackageId>MASES.KNet.Templates</PackageId>
     <Title>KNet Templates - Templates to use the KNet</Title>
     <Authors>MASES s.r.l.</Authors>

--- a/src/net/templates/templates/knetConsumerApp/knetConsumerApp.csproj
+++ b/src/net/templates/templates/knetConsumerApp/knetConsumerApp.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
   <ItemGroup Condition="!Exists('..\..\..\KNet\KNet.csproj')">
     <!--Outside GitHub repo-->
-    <PackageReference Include="MASES.KNet" Version="1.2.2" IncludeAssets="All" PrivateAssets="None" />
+    <PackageReference Include="MASES.KNet" Version="1.2.3" IncludeAssets="All" PrivateAssets="None" />
   </ItemGroup>
 </Project>

--- a/src/net/templates/templates/knetPipeStreamApp/knetPipeStreamApp.csproj
+++ b/src/net/templates/templates/knetPipeStreamApp/knetPipeStreamApp.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
   <ItemGroup Condition="!Exists('..\..\..\KNet\KNet.csproj')">
     <!--Outside GitHub repo-->
-    <PackageReference Include="MASES.KNet" Version="1.2.2" IncludeAssets="All" PrivateAssets="None" />
+    <PackageReference Include="MASES.KNet" Version="1.2.3" IncludeAssets="All" PrivateAssets="None" />
   </ItemGroup>
 </Project>

--- a/src/net/templates/templates/knetProducerApp/knetProducerApp.csproj
+++ b/src/net/templates/templates/knetProducerApp/knetProducerApp.csproj
@@ -12,6 +12,6 @@
   </ItemGroup>
   <ItemGroup Condition="!Exists('..\..\..\KNet\KNet.csproj')">
     <!--Outside GitHub repo-->
-    <PackageReference Include="MASES.KNet" Version="1.2.2" IncludeAssets="All" PrivateAssets="None" />
+    <PackageReference Include="MASES.KNet" Version="1.2.3" IncludeAssets="All" PrivateAssets="None" />
   </ItemGroup>
 </Project>

--- a/tests/KNetBenchmark/KNetBenchmark.csproj
+++ b/tests/KNetBenchmark/KNetBenchmark.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright ©  MASES s.r.l. 2022</Copyright>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>1.2.2.0</Version>
+    <Version>1.2.3.0</Version>
     <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin\</OutputPath>
     <LangVersion>latest</LangVersion>

--- a/tests/KNetTest/KNetTest.csproj
+++ b/tests/KNetTest/KNetTest.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright ©  MASES s.r.l. 2022</Copyright>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>1.2.2.0</Version>
+    <Version>1.2.3.0</Version>
     <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin\</OutputPath>
     <LangVersion>latest</LangVersion>

--- a/tests/KNetTestAdmin/KNetTestAdmin.csproj
+++ b/tests/KNetTestAdmin/KNetTestAdmin.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright ©  MASES s.r.l. 2022</Copyright>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>1.2.2.0</Version>
+    <Version>1.2.3.0</Version>
     <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin\</OutputPath>
 	<LangVersion>latest</LangVersion>

--- a/tests/KNetTestStreams/KNetTestStreams.csproj
+++ b/tests/KNetTestStreams/KNetTestStreams.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright ©  MASES s.r.l. 2022</Copyright>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>1.2.2.0</Version>
+    <Version>1.2.3.0</Version>
 	<TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin\</OutputPath>
 	<LangVersion>latest</LangVersion>

--- a/tests/KNetTopicCopyBenchmark/KNetTopicCopyBenchmark.csproj
+++ b/tests/KNetTopicCopyBenchmark/KNetTopicCopyBenchmark.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright ©  MASES s.r.l. 2022</Copyright>
     <Authors>MASES s.r.l.</Authors>
     <Company>MASES s.r.l.</Company>
-    <Version>1.2.2.0</Version>
+    <Version>1.2.3.0</Version>
     <TargetFrameworks>net461;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <OutputPath>..\..\bin\</OutputPath>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Description
KNetCLI crashes due to a regression in JNet/JCOBridge

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
