### PR TITLE
Fix JNI name of nested classes

### DIFF
--- a/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/ConfigEntry.cs
+++ b/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/ConfigEntry.cs
@@ -75,7 +75,7 @@ namespace MASES.KNet.Clients.Admin
 
         public class ConfigSynonym : JCOBridge.C2JBridge.JVMBridgeBase<Config>
         {
-            public override string ClassName => "org.apache.kafka.clients.admin.ConfigEntry.ConfigSynonym";
+            public override string ClassName => "org.apache.kafka.clients.admin.ConfigEntry$ConfigSynonym";
 
             public string Name => IExecute<string>("name");
 

--- a/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/DeleteAclsResult.cs
+++ b/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/DeleteAclsResult.cs
@@ -33,14 +33,14 @@ namespace MASES.KNet.Clients.Admin
 
         public class FilterResults : JCOBridge.C2JBridge.JVMBridgeBase<FilterResults>
         {
-            public override string ClassName => "org.apache.kafka.clients.admin.DeleteAclsResult.FilterResults";
+            public override string ClassName => "org.apache.kafka.clients.admin.DeleteAclsResult$FilterResults";
 
             public List<FilterResult> Values => IExecute<List<FilterResult>>("values");
         }
 
         public class FilterResult : JCOBridge.C2JBridge.JVMBridgeBase<FilterResult>
         {
-            public override string ClassName => "org.apache.kafka.clients.admin.DeleteAclsResult.FilterResult";
+            public override string ClassName => "org.apache.kafka.clients.admin.DeleteAclsResult$FilterResult";
 
             public AclBinding Binding => IExecute<AclBinding>("binding");
 

--- a/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/DescribeProducersResult.cs
+++ b/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/DescribeProducersResult.cs
@@ -35,7 +35,7 @@ namespace MASES.KNet.Clients.Admin
 
         public class PartitionProducerState : JCOBridge.C2JBridge.JVMBridgeBase<DescribeProducersResult>
         {
-            public override string ClassName => "org.apache.kafka.clients.admin.DescribeProducersResult.PartitionProducerState";
+            public override string ClassName => "org.apache.kafka.clients.admin.DescribeProducersResult$PartitionProducerState";
 
             public PartitionProducerState(List<ProducerState> activeProducers)
                 :base(activeProducers)

--- a/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/DescribeReplicaLogDirsResult.cs
+++ b/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/DescribeReplicaLogDirsResult.cs
@@ -31,7 +31,7 @@ namespace MASES.KNet.Clients.Admin
 
         public class ReplicaLogDirInfo : JCOBridge.C2JBridge.JVMBridgeBase<DescribeReplicaLogDirsResult>
         {
-            public override string ClassName => "org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo";
+            public override string ClassName => "org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult$ReplicaLogDirInfo";
 
             public string GetCurrentReplicaLogDir => IExecute<string>("getCurrentReplicaLogDir");
 

--- a/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/ListOffsetsResult.cs
+++ b/src/net/KNet/ClientSide/BridgedClasses/Clients/Admin/ListOffsetsResult.cs
@@ -47,7 +47,7 @@ namespace MASES.KNet.Clients.Admin
 
         public class ListOffsetsResultInfo : JCOBridge.C2JBridge.JVMBridgeBase<ListOffsetsResultInfo>
         {
-            public override string ClassName => "org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo";
+            public override string ClassName => "org.apache.kafka.clients.admin.ListOffsetsResult$ListOffsetsResultInfo";
 
             [System.Obsolete("This is not public in Apache Kafka API")]
             [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/net/KNet/ClientSide/BridgedClasses/Common/Requests/DescribeLogDirsResponse.cs
+++ b/src/net/KNet/ClientSide/BridgedClasses/Common/Requests/DescribeLogDirsResponse.cs
@@ -24,7 +24,7 @@ namespace MASES.KNet.Common.Requests
 
         public class LogDirInfo : JCOBridge.C2JBridge.JVMBridgeBase<LogDirInfo>
         {
-            public override string ClassName => "org.apache.kafka.common.requests.DescribeLogDirsResponse.LogDirInfo";
+            public override string ClassName => "org.apache.kafka.common.requests.DescribeLogDirsResponse$LogDirInfo";
         }
     }
 }

--- a/src/net/KNet/ClientSide/BridgedClasses/Common/TopicCollection.cs
+++ b/src/net/KNet/ClientSide/BridgedClasses/Common/TopicCollection.cs
@@ -37,14 +37,14 @@ namespace MASES.KNet.Common
 
         public class TopicIdCollection : TopicCollection
         {
-            public override string ClassName => "org.apache.kafka.common.TopicCollection.TopicIdCollection";
+            public override string ClassName => "org.apache.kafka.common.TopicCollection$TopicIdCollection";
 
             public Collection<Uuid> TopicIds => IExecute<Collection<Uuid>>("topicIds");
         }
 
         public class TopicNameCollection : TopicCollection
         {
-            public override string ClassName => "org.apache.kafka.common.TopicCollection.TopicNameCollection";
+            public override string ClassName => "org.apache.kafka.common.TopicCollection$TopicNameCollection";
 
             public Collection<string> TopicNames => IExecute<Collection<string>>("topicNames");
         }

--- a/src/net/KNet/ClientSide/BridgedClasses/Connect/Header/Headers.cs
+++ b/src/net/KNet/ClientSide/BridgedClasses/Connect/Header/Headers.cs
@@ -106,7 +106,7 @@ namespace MASES.KNet.Connect.Header
         public class HeaderTransform : JVMBridgeBase<HeaderTransform>
         {
             public override bool IsInterface => true;
-            public override string ClassName => "org.apache.kafka.connect.header.Headers.HeaderTransform";
+            public override string ClassName => "org.apache.kafka.connect.header.Headers$HeaderTransform";
 
             public Header Apply(Header header) => IExecute<Header>("apply", header);
         }

--- a/src/net/KNet/ClientSide/BridgedClasses/Streams/TopologyDescription.cs
+++ b/src/net/KNet/ClientSide/BridgedClasses/Streams/TopologyDescription.cs
@@ -33,7 +33,7 @@ namespace MASES.KNet.Streams
 
         public class Subtopology : JVMBridgeBase<Subtopology>
         {
-            public override string ClassName => "org.apache.kafka.streams.TopologyDescription.Subtopology";
+            public override string ClassName => "org.apache.kafka.streams.TopologyDescription$Subtopology";
 
             public int Id => IExecute<int>("id");
 
@@ -42,7 +42,7 @@ namespace MASES.KNet.Streams
 
         public class GlobalStore : JVMBridgeBase<GlobalStore>
         {
-            public override string ClassName => "org.apache.kafka.streams.TopologyDescription.GlobalStore";
+            public override string ClassName => "org.apache.kafka.streams.TopologyDescription$GlobalStore";
 
             public Source Source => IExecute<Source>("source");
 
@@ -53,7 +53,7 @@ namespace MASES.KNet.Streams
 
         public class Node : JVMBridgeBase<Node>
         {
-            public override string ClassName => "org.apache.kafka.streams.TopologyDescription.Node";
+            public override string ClassName => "org.apache.kafka.streams.TopologyDescription$Node";
 
             public string Name => IExecute<string>("name");
 
@@ -64,7 +64,7 @@ namespace MASES.KNet.Streams
 
         public class Source : Node
         {
-            public override string ClassName => "org.apache.kafka.streams.TopologyDescription.Source";
+            public override string ClassName => "org.apache.kafka.streams.TopologyDescription$Source";
 
             public Set<string> TopicSet => IExecute<Set<string>>("topicSet");
 
@@ -73,7 +73,7 @@ namespace MASES.KNet.Streams
 
         public class Sink : Node
         {
-            public override string ClassName => "org.apache.kafka.streams.TopologyDescription.Sink";
+            public override string ClassName => "org.apache.kafka.streams.TopologyDescription$Sink";
 
             public string Topic => IExecute<string>("topic");
 
@@ -82,7 +82,7 @@ namespace MASES.KNet.Streams
 
         public class Processor : Node
         {
-            public override string ClassName => "org.apache.kafka.streams.TopologyDescription.Processor";
+            public override string ClassName => "org.apache.kafka.streams.TopologyDescription$Processor";
 
             public Set<string> Stores => IExecute<Set<string>>("stores");
         }


### PR DESCRIPTION
## Description
This PR fixes the name of nested classes which needs the symbol `$`, it was wrongly used the standard separator `.`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
