### PR TITLE
#65: Added fallback value in configuration for exactlyOnceSupport and canDefineTransactionBoundaries

### DIFF
--- a/src/config/connect-knet-source.properties
+++ b/src/config/connect-knet-source.properties
@@ -18,7 +18,7 @@ connector.class=KNetSourceConnector
 tasks.max=1
 knet.dotnet.classname=MASES.KNetTemplate.KNetConnect.KNetConnectSource, knetConnectSource
 # enable following line if Connect state machine invokes exactlyOnceSupport method before infrastructure is ready to receive request in .NET side
-#knet.dotnet.exactlyOnceSupport=true
+#knet.dotnet.source.exactlyOnceSupport=true
 # enable following line if Connect state machine invokes canDefineTransactionBoundaries method before infrastructure is ready to receive request in .NET side
-#knet.dotnet.canDefineTransactionBoundaries=true
+#knet.dotnet.source.canDefineTransactionBoundaries=true
 topic=topic-perf

--- a/src/config/connect-knet-source.properties
+++ b/src/config/connect-knet-source.properties
@@ -17,4 +17,8 @@ name=local-knet-source
 connector.class=KNetSourceConnector
 tasks.max=1
 knet.dotnet.classname=MASES.KNetTemplate.KNetConnect.KNetConnectSource, knetConnectSource
+# enable following line if Connect state machine invokes exactlyOnceSupport method before infrastructure is ready to receive request in .NET side
+#knet.dotnet.exactlyOnceSupport=true
+# enable following line if Connect state machine invokes canDefineTransactionBoundaries method before infrastructure is ready to receive request in .NET side
+#knet.dotnet.canDefineTransactionBoundaries=true
 topic=topic-perf

--- a/src/java/knet/src/main/java/org/mases/knet/connect/source/KNetSourceConnector.java
+++ b/src/java/knet/src/main/java/org/mases/knet/connect/source/KNetSourceConnector.java
@@ -39,11 +39,11 @@ public class KNetSourceConnector extends SourceConnector {
 
     private static final String registrationName = "KNetSourceConnector";
 
-    public static final String DOTNET_EXACTLYONESUPPORT_CONFIG = "knet.dotnet.source.exactlyOnceSupport";
+    public static final String DOTNET_EXACTLYONCESUPPORT_CONFIG = "knet.dotnet.source.exactlyOnceSupport";
     public static final String DOTNET_CANDEFINETRANSACTIONBOUNDARIES_CONFIG = "knet.dotnet.source.canDefineTransactionBoundaries";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef(KNetConnectProxy.CONFIG_DEF)
-            .define(DOTNET_EXACTLYONESUPPORT_CONFIG, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.LOW, "Fallback value if infrastructure is not ready to receive request in .NET side to get exactlyOnceSupport")
+            .define(DOTNET_EXACTLYONCESUPPORT_CONFIG, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.LOW, "Fallback value if infrastructure is not ready to receive request in .NET side to get exactlyOnceSupport")
             .define(DOTNET_CANDEFINETRANSACTIONBOUNDARIES_CONFIG, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.LOW, "Fallback value if infrastructure is not ready to receive request in .NET side to get canDefineTransactionBoundaries");
 
     Object dataToExchange = null;
@@ -156,7 +156,7 @@ public class KNetSourceConnector extends SourceConnector {
         }
         log.info("Fallback Invoke of \"exactlyOnceSupport\" to configuration");
         AbstractConfig parsedConfig = new AbstractConfig(CONFIG_DEF, connectorConfig);
-        Boolean exactlyOnceSupport = parsedConfig.getBoolean(DOTNET_EXACTLYONESUPPORT_CONFIG);
+        Boolean exactlyOnceSupport = parsedConfig.getBoolean(DOTNET_EXACTLYONCESUPPORT_CONFIG);
         if (exactlyOnceSupport.booleanValue()) return ExactlyOnceSupport.SUPPORTED;
         return ExactlyOnceSupport.UNSUPPORTED;
     }

--- a/src/java/knet/src/main/java/org/mases/knet/connect/source/KNetSourceConnector.java
+++ b/src/java/knet/src/main/java/org/mases/knet/connect/source/KNetSourceConnector.java
@@ -39,8 +39,8 @@ public class KNetSourceConnector extends SourceConnector {
 
     private static final String registrationName = "KNetSourceConnector";
 
-    public static final String DOTNET_EXACTLYONESUPPORT_CONFIG = "knet.dotnet.exactlyOnceSupport";
-    public static final String DOTNET_CANDEFINETRANSACTIONBOUNDARIES_CONFIG = "knet.dotnet.canDefineTransactionBoundaries";
+    public static final String DOTNET_EXACTLYONESUPPORT_CONFIG = "knet.dotnet.source.exactlyOnceSupport";
+    public static final String DOTNET_CANDEFINETRANSACTIONBOUNDARIES_CONFIG = "knet.dotnet.source.canDefineTransactionBoundaries";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef(KNetConnectProxy.CONFIG_DEF)
             .define(DOTNET_EXACTLYONESUPPORT_CONFIG, ConfigDef.Type.BOOLEAN, false, ConfigDef.Importance.LOW, "Fallback value if infrastructure is not ready to receive request in .NET side to get exactlyOnceSupport")
@@ -155,7 +155,7 @@ public class KNetSourceConnector extends SourceConnector {
             log.error("Failed Invoke of \"exactlyOnceSupport\"", jcne);
         }
         log.info("Fallback Invoke of \"exactlyOnceSupport\" to configuration");
-        AbstractConfig parsedConfig = new AbstractConfig(CONFIG_DEF, props);
+        AbstractConfig parsedConfig = new AbstractConfig(CONFIG_DEF, connectorConfig);
         Boolean exactlyOnceSupport = parsedConfig.getBoolean(DOTNET_EXACTLYONESUPPORT_CONFIG);
         if (exactlyOnceSupport.booleanValue()) return ExactlyOnceSupport.SUPPORTED;
         return ExactlyOnceSupport.UNSUPPORTED;
@@ -176,7 +176,7 @@ public class KNetSourceConnector extends SourceConnector {
             log.error("Failed Invoke of \"canDefineTransactionBoundaries\"", jcne);
         }
         log.info("Fallback Invoke of \"canDefineTransactionBoundaries\" to configuration");
-        AbstractConfig parsedConfig = new AbstractConfig(CONFIG_DEF, props);
+        AbstractConfig parsedConfig = new AbstractConfig(CONFIG_DEF, connectorConfig);
         Boolean canDefineTransactionBoundaries = parsedConfig.getBoolean(DOTNET_CANDEFINETRANSACTIONBOUNDARIES_CONFIG);
         if (canDefineTransactionBoundaries.booleanValue()) return ConnectorTransactionBoundaries.SUPPORTED;
         return ConnectorTransactionBoundaries.UNSUPPORTED;

--- a/src/net/Documentation/articles/connectSDK.md
+++ b/src/net/Documentation/articles/connectSDK.md
@@ -37,6 +37,14 @@ When the __C:\MyConnect__ folder contains all the files it is possible to run Ap
 > knet -ClassToRun ConnectStandalone connect-standalone.properties connect-knet-sink.properties
 >
 
+### Exactly Once and Transaction properties for Source Connector
+
+From version 3.3.1 of Apache Kafka Connect it is possible to manage Exactly Once and Transaction in the source connector.
+
+Two new fallback options are available in case the infrastructure is not ready to receive request in .NET side to obtain values related to Exactly Once and Transaction:
+- `knet.dotnet.source.exactlyOnceSupport`: set to true if .NET Source Connector supports Exactly Once
+- `knet.dotnet.source.canDefineTransactionBoundaries`: set to true if .NET Source Connector can define Transaction Boundaries
+
 ## Distributed
 
 As stated in [Apache Kafka Connect Guide](https://kafka.apache.org/documentation/#connect ) the distributed version does not use the connector file definition, instead it shall be managed using the REST interface.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Apache Connect Framework can invoke exactlyOnceSupport and canDefineTransactionBoundaries before .NET infrastructure is ready to receive requests. The fallback values in configuration helps to info Connect about behavior of Connector managed from the .NET class defined in `knet.dotnet.classname` property

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fix #65 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
