### PR TITLE
Fix KNetProducerRecord to conform to Apache Kafka expectation

### DIFF
--- a/src/net/KNet/Specific/Producer/KNetProducer.cs
+++ b/src/net/KNet/Specific/Producer/KNetProducer.cs
@@ -126,15 +126,15 @@ namespace MASES.KNet.Producer
         /// <inheritdoc cref="ProducerRecord{K, V}.Topic"/>
         public string Topic { get; private set; }
         /// <inheritdoc cref="ProducerRecord{K, V}.Partition"/>
-        public int Partition { get; private set; }
+        public int? Partition { get; private set; }
         /// <inheritdoc cref="ProducerRecord{K, V}.Key"/>
         public K Key { get; private set; }
         /// <inheritdoc cref="ProducerRecord{K, V}.Value"/>
         public V Value { get; private set; }
         /// <inheritdoc cref="ProducerRecord{K, V}.Timestamp"/>
-        public long Timestamp { get; private set; }
+        public long? Timestamp { get; private set; }
         /// <inheritdoc cref="ProducerRecord{K, V}.DateTime"/>
-        public System.DateTime DateTime => System.DateTimeOffset.FromUnixTimeMilliseconds(Timestamp).DateTime;
+        public System.DateTime? DateTime => Timestamp.HasValue ? System.DateTimeOffset.FromUnixTimeMilliseconds(Timestamp.Value).DateTime : null;
         /// <inheritdoc cref="ProducerRecord{K, V}.Headers"/>
         public Headers Headers { get; private set; }
         /// <inheritdoc cref="object.ToString"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The PR changes the way the data are reported in case they are not set when a `KNetProducerRecord` is created. This will help to conform to Apache Kafka requirements of `ProducerRecord`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closed #223 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
