### PR TITLE
Added `ConsumerInstances` on `KNetCompactedReplicator` to manage the number of active consumers

### DIFF
--- a/tests/KNetClassicTest/Program.cs
+++ b/tests/KNetClassicTest/Program.cs
@@ -26,7 +26,6 @@ using MASES.KNet.TestCommon;
 using Org.Apache.Kafka.Clients.Admin;
 using Org.Apache.Kafka.Clients.Consumer;
 using Org.Apache.Kafka.Clients.Producer;
-using Org.Apache.Kafka.Common.Config;
 using Org.Apache.Kafka.Common.Serialization;
 using System;
 using System.Text;

--- a/tests/KNetCompactedReplicatorTest/Program.cs
+++ b/tests/KNetCompactedReplicatorTest/Program.cs
@@ -63,15 +63,19 @@ namespace MASES.KNetTest
                 serverToUse = args[0];
             }
             var sw = Stopwatch.StartNew();
-            TestValues("TestValues", 100, UpdateModeTypes.OnDelivery);
+            TestValues("TestValues", 100, UpdateModeTypes.OnDelivery, 5);
             sw.Stop();
             Console.WriteLine($"End TestValues in {sw.Elapsed}");
             sw = Stopwatch.StartNew();
-            Test("TestOnDelivery", 100, UpdateModeTypes.OnDelivery | UpdateModeTypes.Delayed);
+            Test("TestOnDelivery", 100, UpdateModeTypes.OnDelivery | UpdateModeTypes.Delayed, 5);
             sw.Stop();
             Console.WriteLine($"End TestOnDelivery in {sw.Elapsed}");
             sw = Stopwatch.StartNew();
-            Test("TestOnConsume", 100, UpdateModeTypes.OnConsume | UpdateModeTypes.Delayed);
+            Test("TestOnConsume", 100, UpdateModeTypes.OnConsume | UpdateModeTypes.Delayed, 5);
+            sw.Stop();
+            Console.WriteLine($"End TestOnConsume in {sw.Elapsed}");
+            sw = Stopwatch.StartNew();
+            Test("TestOnConsumeLessConsumers", 100, UpdateModeTypes.OnConsume | UpdateModeTypes.Delayed, 5, 2);
             sw.Stop();
             Console.WriteLine($"End TestOnConsume in {sw.Elapsed}");
             Console.CancelKeyPress += Console_CancelKeyPress;
@@ -85,11 +89,12 @@ namespace MASES.KNetTest
             if (e.Cancel) resetEvent.Set();
         }
 
-        private static void TestValues(string topicName, int length, UpdateModeTypes type)
+        private static void TestValues(string topicName, int length, UpdateModeTypes type, int partitions, int? consumers = null)
         {
             using (var replicator = new KNetCompactedReplicator<int, TestType>()
             {
-                Partitions = 5,
+                Partitions = partitions,
+                ConsumerInstances = consumers,
                 UpdateMode = type,
                 BootstrapServers = serverToUse,
                 StateName = topicName,
@@ -112,11 +117,12 @@ namespace MASES.KNetTest
             }
         }
 
-        private static void Test(string topicName, int length, UpdateModeTypes type)
+        private static void Test(string topicName, int length, UpdateModeTypes type, int partitions, int? consumers = null)
         {
             using (var replicator = new KNetCompactedReplicator<int, TestType>()
             {
-                Partitions = 5,
+                Partitions = partitions,
+                ConsumerInstances = consumers,
                 UpdateMode = type,
                 BootstrapServers = serverToUse,
                 StateName = topicName,

--- a/tests/KNetCompactedReplicatorTest/Program.cs
+++ b/tests/KNetCompactedReplicatorTest/Program.cs
@@ -16,19 +16,9 @@
 *  Refer to LICENSE for more information.
 */
 
-using Java.Util;
-using MASES.KNet.Admin;
-using MASES.KNet.Common;
-using MASES.KNet.Consumer;
-using MASES.KNet.Extensions;
-using MASES.KNet.Producer;
 using MASES.KNet.Replicator;
-using MASES.KNet.Serialization;
 using MASES.KNet.Serialization.Json;
 using MASES.KNet.TestCommon;
-using Org.Apache.Kafka.Clients.Admin;
-using Org.Apache.Kafka.Clients.Consumer;
-using Org.Apache.Kafka.Clients.Producer;
 using System;
 using System.Diagnostics;
 using System.Threading;

--- a/tests/KNetTestAdmin/Program.cs
+++ b/tests/KNetTestAdmin/Program.cs
@@ -17,7 +17,6 @@
 */
 
 using Java.Util;
-using MASES.KNet;
 using Org.Apache.Kafka.Clients.Admin;
 using Org.Apache.Kafka.Common.Config;
 using MASES.KNet.TestCommon;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The number of consumers allocated from a `KNetCompactedReplicator` can be managed with the new property `ConsumerInstances`; if the property is not set the default behavior remains the previous one: the number of consumers is equal to the partitions requested or read from the topic.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closed #237 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with upgraded test program

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
