### PR TITLE
Improved DeserializeWithHeaders when the input is null

### DIFF
--- a/src/net/KNet.Serialization.Avro/AvroSerDes.cs
+++ b/src/net/KNet.Serialization.Avro/AvroSerDes.cs
@@ -17,7 +17,6 @@
 */
 
 using Org.Apache.Kafka.Common.Header;
-using static System.Net.WebRequestMethods;
 
 namespace MASES.KNet.Serialization.Avro
 {
@@ -31,14 +30,25 @@ namespace MASES.KNet.Serialization.Avro
         /// The extension uses <see cref="Headers"/>
         /// </summary>
         public override bool UseHeaders => true;
+        /// <inheritdoc cref="KNetSerDes{T}.Serialize(string, T)"/>
+        public override byte[] Serialize(string topic, T data)
+        {
+            return SerializeWithHeaders(topic, null, data);
+        }
         /// <inheritdoc cref="KNetSerDes{T}.SerializeWithHeaders(string, Headers, T)"/>
         public override byte[] SerializeWithHeaders(string topic, Headers headers, T data)
         {
             throw new System.NotImplementedException();
         }
+        /// <inheritdoc cref="KNetSerDes{T}.Deserialize(string, byte[])"/>
+        public override T Deserialize(string topic, byte[] data)
+        {
+            return DeserializeWithHeaders(topic, null, data);
+        }
         /// <inheritdoc cref="KNetSerDes{T}.DeserializeWithHeaders(string, Headers, byte[])"/>
         public override T DeserializeWithHeaders(string topic, Headers headers, byte[] data)
         {
+            if (data == null) return default;
             throw new System.NotImplementedException();
         }
     }

--- a/src/net/KNet.Serialization.Json/JsonSerDes.cs
+++ b/src/net/KNet.Serialization.Json/JsonSerDes.cs
@@ -31,6 +31,11 @@ namespace MASES.KNet.Serialization.Json
         /// The extension uses <see cref="Headers"/>
         /// </summary>
         public override bool UseHeaders => true;
+        /// <inheritdoc cref="KNetSerDes{T}.Serialize(string, T)"/>
+        public override byte[] Serialize(string topic, T data)
+        {
+            return SerializeWithHeaders(topic, null, data);
+        }
         /// <inheritdoc cref="KNetSerDes{T}.SerializeWithHeaders(string, Headers, T)"/>
         public override byte[] SerializeWithHeaders(string topic, Headers headers, T data)
         {
@@ -42,9 +47,15 @@ namespace MASES.KNet.Serialization.Json
             return Encoding.UTF8.GetBytes(jsonStr);
 #endif
         }
+        /// <inheritdoc cref="KNetSerDes{T}.Deserialize(string, byte[])"/>
+        public override T Deserialize(string topic, byte[] data)
+        {
+            return DeserializeWithHeaders(topic, null, data);
+        }
         /// <inheritdoc cref="KNetSerDes{T}.DeserializeWithHeaders(string, Headers, byte[])"/>
         public override T DeserializeWithHeaders(string topic, Headers headers, byte[] data)
         {
+            if (data == null) return default;
 #if NET462_OR_GREATER
             var jsonStr = Encoding.UTF8.GetString(data);
             return Newtonsoft.Json.JsonConvert.DeserializeObject<T>(jsonStr);

--- a/src/net/KNet.Serialization.MessagePack/MessagePackSerDes.cs
+++ b/src/net/KNet.Serialization.MessagePack/MessagePackSerDes.cs
@@ -32,14 +32,25 @@ namespace MASES.KNet.Serialization.MessagePack
         /// The extension uses <see cref="Headers"/>
         /// </summary>
         public override bool UseHeaders => true;
+        /// <inheritdoc cref="KNetSerDes{T}.Serialize(string, T)"/>
+        public override byte[] Serialize(string topic, T data)
+        {
+            return SerializeWithHeaders(topic, null, data);
+        }
         /// <inheritdoc cref="KNetSerDes{T}.SerializeWithHeaders(string, Headers, T)"/>
         public override byte[] SerializeWithHeaders(string topic, Headers headers, T data)
         {
             return MessagePackSerializer.Serialize(data);
         }
+        /// <inheritdoc cref="KNetSerDes{T}.Deserialize(string, byte[])"/>
+        public override T Deserialize(string topic, byte[] data)
+        {
+            return DeserializeWithHeaders(topic, null, data);
+        }
         /// <inheritdoc cref="KNetSerDes{T}.DeserializeWithHeaders(string, Headers, byte[])"/>
         public override T DeserializeWithHeaders(string topic, Headers headers, byte[] data)
         {
+            if (data == null) return default;
             using (MemoryStream stream = new MemoryStream(data))
             {
                 return MessagePackSerializer.Deserialize<T>(stream);

--- a/src/net/KNet.Serialization.Protobuf/ProtobufSerDes.cs
+++ b/src/net/KNet.Serialization.Protobuf/ProtobufSerDes.cs
@@ -34,6 +34,11 @@ namespace MASES.KNet.Serialization.Protobuf
         /// The extension uses <see cref="Headers"/>
         /// </summary>
         public override bool UseHeaders => true;
+        /// <inheritdoc cref="KNetSerDes{T}.Serialize(string, T)"/>
+        public override byte[] Serialize(string topic, T data)
+        {
+            return SerializeWithHeaders(topic, null, data);
+        }
         /// <inheritdoc cref="KNetSerDes{T}.SerializeWithHeaders(string, Headers, T)"/>
         public override byte[] SerializeWithHeaders(string topic, Headers headers, T data)
         {
@@ -43,9 +48,15 @@ namespace MASES.KNet.Serialization.Protobuf
                 return stream.ToArray();
             }
         }
+        /// <inheritdoc cref="KNetSerDes{T}.Deserialize(string, byte[])"/>
+        public override T Deserialize(string topic, byte[] data)
+        {
+            return DeserializeWithHeaders(topic, null, data);
+        }
         /// <inheritdoc cref="KNetSerDes{T}.DeserializeWithHeaders(string, Headers, byte[])"/>
         public override T DeserializeWithHeaders(string topic, Headers headers, byte[] data)
         {
+            if (data == null) return default;
             return _parser.ParseFrom(data);
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If the input is `null` the return value is the `default` of the expected type to be deserialized

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closed #244 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Local tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
