### PR TITLE
Added KNetKeySerDes and KNetValueSerDes properties to simplify the usage of external serializers

### DIFF
--- a/src/net/KNet/Specific/Consumer/KNetConsumer.cs
+++ b/src/net/KNet/Specific/Consumer/KNetConsumer.cs
@@ -125,6 +125,16 @@ namespace MASES.KNet.Consumer
         /// <summary>
         /// Initialize a new instance of <see cref="KNetConsumer{K, V}"/>
         /// </summary>
+        /// <param name="configBuilder">An instance of <see cref="ConsumerConfigBuilder"/> </param>
+        /// <param name="useJVMCallback"><see langword="true"/> to active callback based mode</param>
+        public KNetConsumer(ConsumerConfigBuilder configBuilder, bool useJVMCallback = false)
+            : this(configBuilder, configBuilder.BuildKeySerDes<K>(), configBuilder.BuildValueSerDes<V>())
+        {
+            _autoCreateSerDes = true;
+        }
+        /// <summary>
+        /// Initialize a new instance of <see cref="KNetConsumer{K, V}"/>
+        /// </summary>
         /// <param name="props">The properties to use, see <see cref="ConsumerConfig"/> and <see cref="ConsumerConfigBuilder"/></param>
         /// <param name="keyDeserializer">Key serializer base on <see cref="KNetSerDes{K}"/></param>
         /// <param name="valueDeserializer">Value serializer base on <see cref="KNetSerDes{K}"/></param>

--- a/src/net/KNet/Specific/Producer/KNetProducer.cs
+++ b/src/net/KNet/Specific/Producer/KNetProducer.cs
@@ -165,7 +165,7 @@ namespace MASES.KNet.Producer
         /// </summary>
         public override string BridgeClassName => "org.mases.knet.clients.producer.KNetProducer";
 
-        readonly bool autoCreateSerDes = false;
+        readonly bool _autoCreateSerDes = false;
         readonly IKNetSerializer<K> _keySerializer;
         readonly IKNetSerializer<V> _valueSerializer;
         /// <summary>
@@ -175,7 +175,16 @@ namespace MASES.KNet.Producer
         public KNetProducer(Properties props)
             : this(props, new KNetSerDes<K>(), new KNetSerDes<V>())
         {
-            autoCreateSerDes = true;
+            _autoCreateSerDes = true;
+        }
+        /// <summary>
+        /// Initialize a new instance of <see cref="KNetProducer{K, V}"/>
+        /// </summary>
+        /// <param name="configBuilder">An instance of <see cref="ProducerConfigBuilder"/> </param>
+        public KNetProducer(ProducerConfigBuilder configBuilder)
+            : this(configBuilder, configBuilder.BuildKeySerDes<K>(), configBuilder.BuildValueSerDes<V>())
+        {
+            _autoCreateSerDes = true;
         }
         /// <summary>
         /// Initialize a new instance of <see cref="KNetProducer{K, V}"/>
@@ -211,7 +220,7 @@ namespace MASES.KNet.Producer
         /// </summary>
         ~KNetProducer()
         {
-            if (autoCreateSerDes)
+            if (_autoCreateSerDes)
             {
                 _keySerializer?.Dispose();
                 _valueSerializer?.Dispose();

--- a/tests/KNetCompactedReplicatorTest/Program.cs
+++ b/tests/KNetCompactedReplicatorTest/Program.cs
@@ -102,7 +102,8 @@ namespace MASES.KNetTest
                 UpdateMode = type,
                 BootstrapServers = serverToUse,
                 StateName = topicName,
-                ValueSerDes = new JsonSerDes.Value<TestType>(),
+                KNetValueSerDes = typeof(JsonSerDes.Value<>),
+                //ValueSerDes = new JsonSerDes.Value<TestType>(),
             })
             {
                 replicator.StartAndWait();
@@ -130,7 +131,8 @@ namespace MASES.KNetTest
                 UpdateMode = type,
                 BootstrapServers = serverToUse,
                 StateName = topicName,
-                ValueSerDes = new JsonSerDes.Value<TestType>(),
+                KNetValueSerDes = typeof(JsonSerDes.Value<>),
+            //  ValueSerDes = new JsonSerDes.Value<TestType>(),
             })
             {
                 replicator.StartAndWait();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`GenericConfigBuilder<T>` supports `KNetKeySerDes` and `KNetValueSerDes` to use KNet serialization instead to create serializers outside `KNetProducer` and `KNetConsumer`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closed #339 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
