### PR TITLE
Added ability on `ToIEnumerator` to return an `IEnumerator`  instance able to work in parallel and speeding up data retrieve

### DIFF
--- a/src/net/KNet/Specific/Streams/KNetTimestampedKeyValue.cs
+++ b/src/net/KNet/Specific/Streams/KNetTimestampedKeyValue.cs
@@ -18,7 +18,6 @@
 
 using MASES.KNet.Serialization;
 using MASES.KNet.Streams.State;
-using System;
 
 namespace MASES.KNet.Streams
 {
@@ -29,28 +28,44 @@ namespace MASES.KNet.Streams
     /// <typeparam name="TValue">The value type</typeparam>
     public class KNetTimestampedKeyValue<TKey, TValue> : IGenericSerDesFactoryApplier
     {
-        readonly Org.Apache.Kafka.Streams.KeyValue<byte[], Org.Apache.Kafka.Streams.State.ValueAndTimestamp<byte[]>> _value1 = null;
-        readonly Org.Apache.Kafka.Streams.KeyValue<Java.Lang.Long, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<byte[]>> _value2 = null;
+        readonly Org.Apache.Kafka.Streams.KeyValue<byte[], Org.Apache.Kafka.Streams.State.ValueAndTimestamp<byte[]>> _valueInner1 = null;
+        readonly Org.Apache.Kafka.Streams.KeyValue<Java.Lang.Long, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<byte[]>> _valueInner2 = null;
+        readonly bool _fromAsync;
+        readonly TKey _key;
         IKNetSerDes<TKey> _keySerDes = null;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set { _factory = value; } }
 
         internal KNetTimestampedKeyValue(IGenericSerDesFactory factory, 
                                          Org.Apache.Kafka.Streams.KeyValue<byte[], Org.Apache.Kafka.Streams.State.ValueAndTimestamp<byte[]>> value,
-                                         IKNetSerDes<TKey> keySerDes)
+                                         IKNetSerDes<TKey> keySerDes,
+                                         bool fromAsync)
         {
             _factory = factory;
-            _value1 = value;
+            _valueInner1 = value;
             _keySerDes = keySerDes;
+            _fromAsync = fromAsync;
+            if (_fromAsync)
+            {
+                _keySerDes ??= _factory.BuildKeySerDes<TKey>();
+                _key = _keySerDes.Deserialize(null, _valueInner1.key);
+            }
         }
 
         internal KNetTimestampedKeyValue(IGenericSerDesFactory factory, 
                                          Org.Apache.Kafka.Streams.KeyValue<Java.Lang.Long, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<byte[]>> value,
-                                         IKNetSerDes<TKey> keySerDes)
+                                         IKNetSerDes<TKey> keySerDes,
+                                         bool fromAsync)
         {
             _factory = factory;
-            _value2 = value;
+            _valueInner2 = value;
             _keySerDes = keySerDes;
+            _fromAsync = fromAsync;
+            if (_fromAsync)
+            {
+                _keySerDes ??= _factory.BuildKeySerDes<TKey>();
+                _key = (TKey)(object)_valueInner2.key.LongValue();
+            }
         }
 
         /// <summary>
@@ -60,14 +75,15 @@ namespace MASES.KNet.Streams
         {
             get
             {
-                if (_value2 != null && _value2.key != null) { var ll = _value2.key; return (TKey)(object)ll.LongValue(); }
+                if (_fromAsync) return _key;
+                if (_valueInner2 != null && _valueInner2.key != null) { var ll = _valueInner2.key; return (TKey)(object)ll.LongValue(); }
                 _keySerDes ??= _factory.BuildKeySerDes<TKey>();
-                return _keySerDes.Deserialize(null, _value1.key);
+                return _keySerDes.Deserialize(null, _valueInner1.key);
             }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/3.6.1/org/apache/kafka/streams/KeyValue.html#value"/>
         /// </summary>
-        public KNetValueAndTimestamp<TValue> Value => new KNetValueAndTimestamp<TValue>(_factory, _value1 != null ? _value1.value : _value2.value);
+        public KNetValueAndTimestamp<TValue> Value => new KNetValueAndTimestamp<TValue>(_factory, _valueInner1 != null ? _valueInner1.value : _valueInner2.value);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`ToIEnumerator` can return a special `IEnumerator` able to deserialize in parallel while it is moving along the data, speeding up data retrieve

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix #327 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test on KEFCore
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
