### PR TITLE
Update documentation and removed unneeded resource consumption

### DIFF
--- a/src/net/KNet/Specific/Streams/KNetTimestampedWindowedKeyValue.cs
+++ b/src/net/KNet/Specific/Streams/KNetTimestampedWindowedKeyValue.cs
@@ -29,7 +29,9 @@ namespace MASES.KNet.Streams
     /// <typeparam name="TValue">The value type</typeparam>
     public class KNetTimestampedWindowedKeyValue<TKey, TValue> : IGenericSerDesFactoryApplier
     {
-        readonly Org.Apache.Kafka.Streams.KeyValue<Org.Apache.Kafka.Streams.Kstream.Windowed<byte[]>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<byte[]>> _value;
+        readonly Org.Apache.Kafka.Streams.KeyValue<Org.Apache.Kafka.Streams.Kstream.Windowed<byte[]>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<byte[]>> _valueInner;
+        KNetWindowed<TKey> _key = null;
+        KNetValueAndTimestamp<TValue> _value = null;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set { _factory = value; } }
 
@@ -37,7 +39,7 @@ namespace MASES.KNet.Streams
                                                  Org.Apache.Kafka.Streams.KeyValue<Org.Apache.Kafka.Streams.Kstream.Windowed<byte[]>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<byte[]>> value)
         {
             _factory = factory;
-            _value = value;
+            _valueInner = value;
         }
 
         /// <summary>
@@ -47,8 +49,8 @@ namespace MASES.KNet.Streams
         {
             get
             {
-                var kk = _value.key;
-                return new KNetWindowed<TKey>(_factory, kk);
+                _key ??= new KNetWindowed<TKey>(_factory, _valueInner.key);
+                return _key;
             }
         }
         /// <summary>
@@ -58,8 +60,8 @@ namespace MASES.KNet.Streams
         {
             get
             {
-                var kk = _value.value;
-                return new KNetValueAndTimestamp<TValue>(_factory, kk);
+                _value ??= new KNetValueAndTimestamp<TValue>(_factory, _valueInner.value);
+                return _value;
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Requests on properties of `KNetKeyValue`, `KNetTimestampedKeyValue`, `KNetTimestampedWindowedKeyValue`, `KNetWindowedKeyValue` produces results can be cached to avoid unneeded consumption of resources: data managed from the classes are immutable so does not change in their lifetime.

- Updated documentation of KNet Streams SDK.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix #327 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
