### PR TITLE
Make RecordMetadata.DateTime nullable (#1403)

### DIFF
--- a/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Producer/RecordMetadata.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Producer/RecordMetadata.cs
@@ -21,8 +21,8 @@ namespace Org.Apache.Kafka.Clients.Producer
     public partial class RecordMetadata
     {
         /// <summary>
-        /// <see cref="System.DateTime"/> of <see cref="Timestamp"/>
+        /// <see cref="System.DateTime"/> of <see cref="Timestamp"/> or <see langword="null"/> if <see cref="HasTimestamp"/> return <see langword="false"/>
         /// </summary>
-        public System.DateTime DateTime => System.DateTimeOffset.FromUnixTimeMilliseconds((long)Timestamp()).DateTime;
+        public System.DateTime? DateTime => HasTimestamp() ? System.DateTimeOffset.FromUnixTimeMilliseconds(Timestamp()).DateTime : null;
     }
 }

--- a/tests/net/Benchmarks/KNetBenchmark/ProgramInit.cs
+++ b/tests/net/Benchmarks/KNetBenchmark/ProgramInit.cs
@@ -423,6 +423,11 @@ namespace MASES.KNet.Benchmark
             BenchmarkKNetCore.ApplicationJarRootPath = Const.DefaultJarsPath;
             BenchmarkKNetCore.ApplicationHeapSize = "4G";
             BenchmarkKNetCore.ApplicationInitialHeapSize = "4G";
+            if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != null)  // for GitHub problem with Linux container
+            {
+                BenchmarkKNetCore.ApplicationIgnoreUnrecognized = true; // add this condition if the JVM does not support the UseContainerSupport JVM switch
+                BenchmarkKNetCore.AddJVMOption("-XX:-UseContainerSupport"); // remove the check which generates error in CGroup
+            }
             BenchmarkKNetCore.CreateGlobalInstance();
 
             Console.WriteLine($"Unknown params: {string.Join(", ", BenchmarkKNetCore.FilteredArgs)}");

--- a/tests/net/Common/SharedKNetCore.cs
+++ b/tests/net/Common/SharedKNetCore.cs
@@ -81,6 +81,11 @@ namespace MASES.KNet.TestCommon
         {
             ApplicationWriteEventOrExceptionOnCmdLine = true;
             ApplicationJarRootPath = Const.DefaultJarsPath;
+            if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != null)  // for GitHub problem with Linux container
+            {
+                ApplicationIgnoreUnrecognized = true; // add this condition if the JVM does not support the UseContainerSupport JVM switch
+                AddJVMOption("-XX:-UseContainerSupport"); // remove the check which generates error in CGroup
+            }
             CreateGlobalInstance();
             if (GlobalInstance == null)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Make RecordMetadata.DateTime nullable

Return a nullable DateTime for RecordMetadata.DateTime and guard conversion with HasTimestamp(). This avoids producing a DateTime for records without a timestamp (returns null instead). Also updated the XML doc comment to reflect the nullable return and changed the conversion logic to only call Timestamp() when HasTimestamp() is true.

* Apply the fix for test execution on GitHub

Applies the fix of masesgroup/KEFCore#446 to avoid errors when executing some tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix #1402 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
