### PR TITLE
Set ReflectedRemoteObjectClassName for transforms (#1414)

### DIFF
--- a/src/net/KNet/Specific/Connect/KNetCommon.cs
+++ b/src/net/KNet/Specific/Connect/KNetCommon.cs
@@ -149,6 +149,7 @@ namespace MASES.KNet.Connect
         /// <summary>
         /// The unique name used to map objects between JVM and .NET
         /// </summary>
+        /// <remarks>This value is used when KNet Connect SDK is hosted in the CLR. When KNet Connect SDK starts from the JVM it is ignored.</remarks>
         protected abstract string ReflectedRemoteObjectClassName { get; }
 
         #region IKNetConnectLogging

--- a/src/net/KNet/Specific/Connect/Transforms/KNetTransformation.cs
+++ b/src/net/KNet/Specific/Connect/Transforms/KNetTransformation.cs
@@ -96,6 +96,11 @@ namespace MASES.KNet.Connect.Transforms
         public IReadOnlyDictionary<string, object> Properties { get; private set; }
 
         /// <summary>
+        /// Set the <see cref="ReflectedRemoteObjectClassName"/> of the connector to a fixed value
+        /// </summary>
+        protected sealed override string ReflectedRemoteObjectClassName => "KNetTransformation";
+
+        /// <summary>
         /// Public method used from Java to trigger <see cref="Apply(ConnectRecord)"/>
         /// </summary>
         public void ApplyInternal()

--- a/src/net/KNet/Specific/Connect/Transforms/Predicates/KNetPredicate.cs
+++ b/src/net/KNet/Specific/Connect/Transforms/Predicates/KNetPredicate.cs
@@ -100,6 +100,11 @@ namespace MASES.KNet.Connect.Transforms.Predicates
         public IReadOnlyDictionary<string, object> Properties { get; private set; }
 
         /// <summary>
+        /// Set the <see cref="ReflectedRemoteObjectClassName"/> of the connector to a fixed value
+        /// </summary>
+        protected sealed override string ReflectedRemoteObjectClassName => "KNetPredicate";
+
+        /// <summary>
         /// Public method used from Java to trigger <see cref="Test(ConnectRecord)"/>
         /// </summary>
         public bool TestInternal()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Document ReflectedRemoteObjectClassName usage in KNetCommon and add sealed overrides in KNetTransformation and KNetPredicate to return fixed class names ("KNetTransformation" and "KNetPredicate"). This ensures the connector's reflected JVM class name is set when the KNet Connect SDK is hosted in the CLR (ignored when starting from the JVM). Overrides are sealed to prevent further customization.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
