### PR TITLE
Review KNet Connect SDK configuration (#1429)

### DIFF
--- a/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/KNetConnectProxy.java
+++ b/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/KNetConnectProxy.java
@@ -40,8 +40,8 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
     public static final String CONNECTOR_ID_PROP_NAME = "connector.id.prop.name";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(DOTNET_ASSEMBLY_LOCATION_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, "Location of the assembly containing the .NET class referred from \"knet.dotnet.classname\".")
-            .define(DOTNET_CLASSNAME_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, ".NET class name in the form usable from .NET like \"classname, assembly name\".");
+            .define(DOTNET_ASSEMBLY_LOCATION_CONFIG, ConfigDef.Type.STRING, "", ConfigDef.Importance.LOW, "Location of the assembly containing the .NET class referred from \"knet.dotnet.classname\".")
+            .define(DOTNET_CLASSNAME_CONFIG, ConfigDef.Type.STRING, "", ConfigDef.Importance.HIGH, ".NET class name in the form usable from .NET like \"classname, assembly name\".");
 
     static JCOBridge bridgeInstance = null;
     static JCObject knetConnectProxy = null;
@@ -76,7 +76,7 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
                 knetConnectProxy = (JCObject) JCOBridge.GetCLRGlobal("KNetConnectProxy");
                 log.info("Recovered KNetConnectProxy from CLR");
             } else {
-                log.info("Creating JCOBRidge instance");
+                log.info("Creating JCOBridge instance");
                 bridgeInstance = JCOBridge.CreateNew();
                 log.info("Allocating KNetConnectProxy instance in CLR");
                 knetConnectProxy = (JCObject) bridgeInstance.NewObject("MASES.KNet.Connect.KNetConnectProxy, MASES.KNet");
@@ -100,12 +100,12 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
         if (sink != null) {
             className = sink.getClassName();
         }
-        if (className == null) {
+        if (className == null || className.isEmpty()) {
             AbstractConfig parsedConfig = new AbstractConfig(CONFIG_DEF, props);
             className = parsedConfig.getString(DOTNET_CLASSNAME_CONFIG);
         }
 
-        if (className == null)
+        if (className == null || className.isEmpty())
             throw new ConfigException(String.format("'%s' in KNetSinkConnector configuration requires a definition", DOTNET_CLASSNAME_CONFIG));
 
         log.info("Trying to allocate Sink Connector with class name {}", className);
@@ -123,12 +123,12 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
         if (source != null) {
             className = source.getClassName();
         }
-        if (className == null) {
+        if (className == null || className.isEmpty()) {
             AbstractConfig parsedConfig = new AbstractConfig(CONFIG_DEF, props);
             className = parsedConfig.getString(DOTNET_CLASSNAME_CONFIG);
         }
 
-        if (className == null)
+        if (className == null || className.isEmpty())
             throw new ConfigException(String.format("'%s' in KNetSourceConnector configuration requires a definition", DOTNET_CLASSNAME_CONFIG));
 
         log.info("Trying to allocate Source Connector with class name {}", className);
@@ -147,10 +147,10 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
         if (connector != null) {
             location = connector.getAssemblyLocation();
         }
-        if (location == null) {
+        if (location == null || location.isEmpty()) {
             location = parsedConfig.getString(DOTNET_ASSEMBLY_LOCATION_CONFIG);
         }
-        if (location != null) {
+        if (location != null && !location.isEmpty()) {
             if (bridgeInstance == null)
                 throw new ConnectException("Missing initialization of infrastructure using initAndGetConnectProxy");
             bridgeInstance.AddPath(location);
@@ -160,11 +160,11 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
         if (connector != null) {
             className = connector.getClassName();
         }
-        if (className == null) {
+        if (className == null || className.isEmpty()) {
             className = parsedConfig.getString(DOTNET_CLASSNAME_CONFIG);
         }
 
-        if (className == null)
+        if (className == null || className.isEmpty())
             throw new ConfigException(String.format("'%s' in connector configuration requires a definition", DOTNET_CLASSNAME_CONFIG));
 
         log.info("Trying to allocate Connector with class name {}", className);
@@ -183,10 +183,10 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
         if (connector != null) {
             location = connector.getAssemblyLocation();
         }
-        if (location == null) {
+        if (location == null || location.isEmpty()) {
             location = parsedConfig.getString(DOTNET_ASSEMBLY_LOCATION_CONFIG);
         }
-        if (location != null) {
+        if (location != null && !location.isEmpty()) {
             if (bridgeInstance == null)
                 throw new ConnectException("Missing initialization of infrastructure using initAndGetConnectProxy");
             bridgeInstance.AddPath(location);
@@ -196,11 +196,11 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
         if (connector != null) {
             className = connector.getClassName();
         }
-        if (className == null) {
+        if (className == null || className.isEmpty()) {
             className = parsedConfig.getString(DOTNET_CLASSNAME_CONFIG);
         }
 
-        if (className == null)
+        if (className == null || className.isEmpty())
             throw new ConfigException(String.format("'%s' in transform configuration requires a definition", DOTNET_CLASSNAME_CONFIG));
 
         log.info("Trying to allocate Transform with class name {}", className);
@@ -219,10 +219,10 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
         if (connector != null) {
             location = connector.getAssemblyLocation();
         }
-        if (location == null) {
+        if (location == null || location.isEmpty()) {
             location = parsedConfig.getString(DOTNET_ASSEMBLY_LOCATION_CONFIG);
         }
-        if (location != null) {
+        if (location != null && !location.isEmpty()) {
             if (bridgeInstance == null)
                 throw new ConnectException("Missing initialization of infrastructure using initAndGetConnectProxy");
             bridgeInstance.AddPath(location);
@@ -232,11 +232,11 @@ public class KNetConnectProxy implements KNetConnectLogging, IJCEventLog {
         if (connector != null) {
             className = connector.getClassName();
         }
-        if (className == null) {
+        if (className == null || className.isEmpty()) {
             className = parsedConfig.getString(DOTNET_CLASSNAME_CONFIG);
         }
 
-        if (className == null)
+        if (className == null || className.isEmpty())
             throw new ConfigException(String.format("'%s' in predicate configuration requires a definition", DOTNET_CLASSNAME_CONFIG));
 
         log.info("Trying to allocate Predicate with class name {}", className);

--- a/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/sink/KNetSinkConnector.java
+++ b/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/sink/KNetSinkConnector.java
@@ -19,6 +19,7 @@
 package org.mases.knet.developed.connect.sink;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -122,7 +123,8 @@ public class KNetSinkConnector extends SinkConnector implements KNetConnectLoggi
             }
             try {
                 log.debug("Executing StartInternal");
-                dataToExchange = props;
+                AbstractConfig config = new AbstractConfig(config(), props);
+                dataToExchange = config.values();
                 sink.Invoke("StartInternal");
             } finally {
                 dataToExchange = null;

--- a/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/source/KNetSourceConnector.java
+++ b/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/source/KNetSourceConnector.java
@@ -125,7 +125,8 @@ public class KNetSourceConnector extends SourceConnector implements KNetConnectL
                 source = sourceConnector;
             }
             try {
-                dataToExchange = props;
+                AbstractConfig config = new AbstractConfig(config(), props);
+                dataToExchange = config.values();
                 source.Invoke("StartInternal");
             } finally {
                 dataToExchange = null;

--- a/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/transforms/KNetTransformation.java
+++ b/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/transforms/KNetTransformation.java
@@ -18,6 +18,7 @@
 
 package org.mases.knet.developed.connect.transforms;
 
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.components.Versioned;
@@ -153,7 +154,8 @@ public class KNetTransformation<R extends ConnectRecord<R>> implements Transform
             }
             if (transformationObject != null) {
                 try {
-                    dataToExchange = configs;
+                    AbstractConfig config = new AbstractConfig(config(), configs);
+                    dataToExchange = config.values();
                     transformationObject.Invoke("ConfigureInternal");
                 } finally {
                     dataToExchange = null;

--- a/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/transforms/predicates/KNetPredicate.java
+++ b/src/jvm/knet/src/main/java/org/mases/knet/developed/connect/transforms/predicates/KNetPredicate.java
@@ -18,6 +18,7 @@
 
 package org.mases.knet.developed.connect.transforms.predicates;
 
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.components.Versioned;
@@ -150,7 +151,8 @@ public class KNetPredicate<R extends ConnectRecord<R>> implements Predicate<R>, 
             }
             if (predicateObject != null) {
                 try {
-                    dataToExchange = configs;
+                    AbstractConfig config = new AbstractConfig(config(), configs);
+                    dataToExchange = config.values();
                     predicateObject.Invoke("ConfigureInternal");
                 } finally {
                     dataToExchange = null;

--- a/src/net/KNet/Generated/.editorconfig
+++ b/src/net/KNet/Generated/.editorconfig
@@ -1,0 +1,6 @@
+[*.cs]
+generated_code = true
+dotnet_analyzer_diagnostic.severity = none
+dotnet_diagnostic.CS0108.severity = none
+dotnet_diagnostic.CS0419.severity = none
+dotnet_diagnostic.CS1574.severity = none

--- a/src/net/KNet/Specific/Connect/KNetCommon.cs
+++ b/src/net/KNet/Specific/Connect/KNetCommon.cs
@@ -18,18 +18,372 @@
 
 using Java.Lang;
 using Java.Util;
+using Javax.Swing;
 using MASES.JCOBridge.C2JBridge;
 using MASES.JCOBridge.C2JBridge.JVMInterop;
 using MASES.JNet.Specific.Extensions;
+using MASES.KNet.Connect.Transforms;
 using Org.Apache.Kafka.Common.Config;
+using Org.Apache.Kafka.Common.Config.Types;
 using Org.Apache.Kafka.Connect.Connector;
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Xml;
 
 namespace MASES.KNet.Connect
 {
+    #region IKNetConnectConfiguration
+    /// <summary>
+    /// Interface to simplify access configuration information
+    /// </summary>
+    public interface IKNetConnectConfiguration : IEnumerable<KeyValuePair<string, object>>
+    {
+        /// <summary>
+        /// Returns <see langword="true"/> if the <paramref name="key"/> exist
+        /// </summary>
+        /// <param name="key">The key to check</param>
+        /// <returns><see langword="short"/> if the <paramref name="key"/> exist</returns>
+        bool Exist(string key);
+        /// <summary>
+        /// Returns <see langword="short"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <returns>The <see langword="short"/> associated to <paramref name="key"/></returns>
+        short GetShort(string key);
+        /// <summary>
+        /// Returns <see langword="int"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <returns>The <see langword="int"/> associated to <paramref name="key"/></returns>
+        int GetInt(string key);
+        /// <summary>
+        /// Returns <see langword="long"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <returns>The <see langword="long"/> associated to <paramref name="key"/></returns>
+        long GetLong(string key);
+        /// <summary>
+        /// Returns <see langword="double"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <returns>The <see langword="double"/> associated to <paramref name="key"/></returns>
+        double GetDouble(string key);
+        /// <summary>
+        /// Returns <see cref="System.Collections.Generic.List{T}"/> of <see langword="string"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <returns>The <see cref="System.Collections.Generic.List{T}"/> of <see langword="string"/> associated to <paramref name="key"/></returns>
+        System.Collections.Generic.List<string> GetList(string key);
+        /// <summary>
+        /// Returns <see langword="bool"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <returns>The <see langword="bool"/> associated to <paramref name="key"/></returns>
+        bool GetBoolean(string key);
+        /// <summary>
+        /// Returns <see langword="string"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <returns>The <see langword="string"/> associated to <paramref name="key"/></returns>
+        string GetString(string key);
+        /// <summary>
+        /// Returns <see cref="Password"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <returns>The <see cref="Password"/> associated to <paramref name="key"/></returns>
+        Password GetPassword(string key);
+        /// <summary>
+        /// Returns <see cref="Class"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <returns>The <see cref="Class"/> associated to <paramref name="key"/></returns>
+        Class GetClass(string key);
+    }
+
+    #endregion
+
+    #region KNetConnectConfiguration
+    /// <summary>
+    /// Interface to simplify access configuration information
+    /// </summary>
+    class KNetConnectConfiguration : IKNetConnectConfiguration
+    {
+        readonly Map<Java.Lang.String, object> _configuration;
+        readonly Map<Java.Lang.String, Java.Lang.String> _configuration1;
+        public KNetConnectConfiguration(Map<Java.Lang.String, object> configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public KNetConnectConfiguration(Map<Java.Lang.String, Java.Lang.String> configuration)
+        {
+            _configuration1 = configuration;
+        }
+
+        object GetValue(string key)
+        {
+            if (_configuration != null && _configuration.ContainsKey(key))
+            {
+                return _configuration.Get(key);
+            }
+            else if (_configuration1 != null)
+            {
+                throw new InvalidOperationException($"Only string values can be read.");
+            }
+            throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
+        }
+
+        /// <inheritdoc/>
+        public bool Exist(string key)
+        {
+            return (_configuration != null) ? _configuration.ContainsKey(key) : _configuration1.ContainsKey(key);
+        }
+        /// <inheritdoc/>
+        public short GetShort(string key)
+        {
+            if (_configuration1 != null)
+            {
+                if (_configuration1.ContainsKey(key))
+                {
+                    var value = _configuration1.Get(key);
+                    return short.TryParse(value, out var converted) ? converted
+                                                                    : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in short"); ;
+                }
+                throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
+            }
+
+            var result = GetValue(key);
+
+            if (result is short data)
+            {
+                return data;
+            }
+            else if (result is IJavaObject obj)
+            {
+                return obj.Convert<short>();
+            }
+            else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in short");
+        }
+        /// <inheritdoc/>
+        public int GetInt(string key)
+        {
+            if (_configuration1 != null)
+            {
+                if (_configuration1.ContainsKey(key))
+                {
+                    var value = _configuration1.Get(key);
+                    return int.TryParse(value, out var converted) ? converted
+                                                                  : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in int"); ;
+                }
+                throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
+            }
+
+            var result = GetValue(key);
+
+            if (result is int data)
+            {
+                return data;
+            }
+            else if (result is IJavaObject obj)
+            {
+                return obj.Convert<int>();
+            }
+            else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in int");
+        }
+        /// <inheritdoc/>
+        public long GetLong(string key)
+        {
+            if (_configuration1 != null)
+            {
+                if (_configuration1.ContainsKey(key))
+                {
+                    var value = _configuration1.Get(key);
+                    return long.TryParse(value, out var converted) ? converted
+                                                                   : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in long"); ;
+                }
+                throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
+            }
+
+            var result = GetValue(key);
+
+            if (result is long data)
+            {
+                return data;
+            }
+            else if (result is IJavaObject obj)
+            {
+                return obj.Convert<long>();
+            }
+            else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in long");
+        }
+        /// <inheritdoc/>
+        public double GetDouble(string key)
+        {
+            if (_configuration1 != null)
+            {
+                if (_configuration1.ContainsKey(key))
+                {
+                    var value = _configuration1.Get(key);
+                    return double.TryParse(value, out var converted) ? converted
+                                                                     : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in double"); ;
+                }
+                throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
+            }
+
+            var result = GetValue(key);
+
+            if (result is double data)
+            {
+                return data;
+            }
+            else if (result is IJavaObject obj)
+            {
+                return obj.Convert<double>();
+            }
+            else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in double");
+        }
+        /// <inheritdoc/>
+        public System.Collections.Generic.List<string> GetList(string key)
+        {
+            if (_configuration1 != null)
+            {
+                throw new InvalidOperationException($"Cannot manage configuration key \"{key}\" as List.");
+            }
+
+            var result = GetValue(key);
+
+            if (result is IJavaObject obj)
+            {
+                var lst = JVMBridgeBase.WrapsDirect<Java.Util.List<Java.Lang.String>>(obj);
+                System.Collections.Generic.List<string> newLst = new System.Collections.Generic.List<string>();
+                foreach (var item in lst)
+                {
+                    newLst.Add(item);
+                }
+                return newLst;
+            }
+            else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in short");
+        }
+        /// <inheritdoc/>
+        public bool GetBoolean(string key)
+        {
+            if (_configuration1 != null)
+            {
+                if (_configuration1.ContainsKey(key))
+                {
+                    var value = _configuration1.Get(key);
+                    return bool.TryParse(value, out var converted) ? converted
+                                                                   : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in bool"); ;
+                }
+                throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
+            }
+
+            var result = GetValue(key);
+
+            if (result is bool data)
+            {
+                return data;
+            }
+            else if (result is IJavaObject obj)
+            {
+                return obj.Convert<bool>();
+            }
+            else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in bool");
+        }
+        /// <inheritdoc/>
+        public string GetString(string key)
+        {
+            if (_configuration1 != null)
+            {
+                if (_configuration1.ContainsKey(key))
+                {
+                    return _configuration1.Get(key);
+                }
+                throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
+            }
+
+            var result = GetValue(key);
+
+            if (result is string data)
+            {
+                return data;
+            }
+            else if (result is IJavaObject obj)
+            {
+                return obj.Convert<string>();
+            }
+            else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in string");
+        }
+        /// <inheritdoc/>
+        public Password GetPassword(string key)
+        {
+            if (_configuration1 != null)
+            {
+                throw new InvalidOperationException($"Cannot manage configuration key \"{key}\" as Password.");
+            }
+
+            var result = GetValue(key);
+
+            if (result is Password data)
+            {
+                return data;
+            }
+            else if (result is IJavaObject obj)
+            {
+                return JVMBridgeBase.WrapsDirect<Password>(obj);
+            }
+            else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in Password");
+        }
+        /// <inheritdoc/>
+        public Class GetClass(string key)
+        {
+            if (_configuration1 != null)
+            {
+                throw new InvalidOperationException($"Cannot manage configuration key \"{key}\" as Class.");
+            }
+
+            var result = GetValue(key);
+
+            if (result is Class data)
+            {
+                return data;
+            }
+            else if (result is IJavaObject obj)
+            {
+                return JVMBridgeBase.WrapsDirect<Class>(obj);
+            }
+            else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in Class");
+        }
+        /// <inheritdoc/>
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            if (_configuration != null)
+            {
+                foreach (var item in _configuration.EntrySet())
+                {
+                    yield return new KeyValuePair<string, object>(item.Key, item.Value);
+                }
+            }
+            else if (_configuration1 != null)
+            {
+                foreach (var item in _configuration1.EntrySet())
+                {
+                    yield return new KeyValuePair<string, object>(item.Key, item.Value);
+                }
+            }
+            else throw new InvalidOperationException("Unable to execute enumeration.");
+        }
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    #endregion
+
     #region IKNetCommon
     /// <summary>
     /// Helper interface for <see cref="KNetCommon"/>
@@ -37,15 +391,18 @@ namespace MASES.KNet.Connect
     public interface IKNetCommon : IKNetConnectLogging
     {
         /// <summary>
+        /// The properties received during configuration step
+        /// </summary>
+        IKNetConnectConfiguration Properties { get; }
+        /// <summary>
         /// An helper function to execute operation in the Java side
         /// </summary>
         /// <param name="method">Method name to be invoked</param>
         /// <param name="args">Arguments of the <paramref name="method"/> to be invoked</param>
         /// <exception cref="InvalidOperationException"> </exception>
         void ExecuteOnRemote(string method, params object[] args);
-
         /// <summary>
-        /// An helper function to read the data from Java side
+        /// An helper function to operation in the Java side
         /// </summary>
         /// <typeparam name="T">The expected return <see cref="Type"/></typeparam>
         /// <param name="method">Method name to be invoked</param>
@@ -91,11 +448,11 @@ namespace MASES.KNet.Connect
         protected string UniqueId => _uniqueId != null ? _uniqueId : ReflectedRemoteObjectClassName;
 
         /// <summary>
-        /// An helper function to execute operation in the Java side
+        /// The properties received during configuration step
         /// </summary>
-        /// <param name="method">Method name to be invoked</param>
-        /// <param name="args">Arguments of the <paramref name="method"/> to be invoked</param>
-        /// <exception cref="InvalidOperationException"> </exception>
+        public IKNetConnectConfiguration Properties { get; protected set; }
+
+        /// <inheritdoc/>
         public void ExecuteOnRemote(string method, params object[] args)
         {
             reflectedConnectorOrTask ??= KNetConnectProxy.GetJVMGlobal(UniqueId);
@@ -103,18 +460,11 @@ namespace MASES.KNet.Connect
             else throw new InvalidOperationException($"{UniqueId} was not registered in global JVM");
         }
 
-        /// <summary>
-        /// An helper function to read the data from Java side
-        /// </summary>
-        /// <typeparam name="T">The expected return <see cref="Type"/></typeparam>
-        /// <param name="method">Method name to be invoked</param>
-        /// <param name="args">Arguments of the <paramref name="method"/> to be invoked</param>
-        /// <returns>The <typeparamref name="T"/></returns>
-        /// <exception cref="InvalidOperationException"> </exception>
+        /// <inheritdoc/>
         public T ExecuteOnRemote<T>(string method, params object[] args)
         {
             reflectedConnectorOrTask ??= KNetConnectProxy.GetJVMGlobal(UniqueId);
-            return (reflectedConnectorOrTask != null) ? reflectedConnectorOrTask.Invoke<T>(method, args) 
+            return (reflectedConnectorOrTask != null) ? reflectedConnectorOrTask.Invoke<T>(method, args)
                                                       : throw new InvalidOperationException($"{UniqueId} was not registered in global JVM");
         }
 

--- a/src/net/KNet/Specific/Connect/KNetConnector.cs
+++ b/src/net/KNet/Specific/Connect/KNetConnector.cs
@@ -53,7 +53,7 @@ namespace MASES.KNet.Connect
         /// <inheritdoc cref="Connector.Initialize(ConnectorContext, Java.Util.List{Map{Java.Lang.String, Java.Lang.String}})"/>
         void Initialize(ConnectorContext ctx, Java.Util.List<Map<Java.Lang.String, Java.Lang.String>> taskConfigs);
         /// <inheritdoc cref="Connector.Start(Map{Java.Lang.String, Java.Lang.String})"/>
-        void Start(Map<Java.Lang.String, Java.Lang.String> props);
+        void Start(Map<Java.Lang.String, object> props);
         /// <inheritdoc cref="Connector.Reconfigure(Map{Java.Lang.String, Java.Lang.String})"/>
         void Reconfigure(Map<Java.Lang.String, Java.Lang.String> props);
         /// <inheritdoc cref="Connector.TaskClass{ReturnExtendsOrg_Apache_Kafka_Connect_Connector_Task}"/>
@@ -76,10 +76,6 @@ namespace MASES.KNet.Connect
     public interface IKNetConnector : IKNetCommon, IConnector
     {
         /// <summary>
-        /// The properties retrieved from <see cref="KNetConnector.StartInternal"/>
-        /// </summary>
-        IReadOnlyDictionary<string, string> Properties { get; }
-        /// <summary>
         /// Allocates a task object based on <see cref="KNetTask"/>
         /// </summary>
         /// <param name="taskId">The unique id generated from JAva side</param>
@@ -96,19 +92,19 @@ namespace MASES.KNet.Connect
         /// <summary>
         /// Implement the method to execute the start action
         /// </summary>
-        /// <param name="props">The set of properties returned from Apache Kafka Connect framework: the <see cref="IReadOnlyDictionary{TKey, TValue}"/> contains the same info from configuration file.</param>
-        void Start(IReadOnlyDictionary<string, string> props);
+        /// <param name="configuration">The <see cref="IKNetConnectConfiguration"/> to access the properties returned from Apache Kafka Connect framework: the <see cref="IKNetCommon.Properties"/> contains the same info from configuration file.</param>
+        void Start(IKNetConnectConfiguration configuration);
         /// <summary>
         /// Invoked during allocation of tasks from Apache Kafka Connect
         /// </summary>
         /// <param name="currentTask">The actual task index</param>
         /// <param name="maxTasks">Max tasks as defined from Apache Kafka Connect framework</param>
-        /// <param name="config">The <see cref="IDictionary{TKey, TValue}"/> to be filled in with properties for the task: the same will be received from <see cref="KNetTask.Start(IReadOnlyDictionary{string, string})"/></param>
+        /// <param name="config">The <see cref="IKNetTaskConfiguration"/> to be filled in with properties for the task: the same will be received from <see cref="KNetTask.Start(IKNetConnectConfiguration)"/></param>
         /// <returns><see langword="true"/> to avoid any further invocation of the method, otherwise <see langword="false"/>.</returns>
         /// <remarks>If the connector needs a single task and <paramref name="maxTasks"/> is higher than 1, returning <see langword="true"/> immediately only one configuration is returned to Apache Kafka Connect framework. 
         /// In other word it is possible to stop the configuration requests at any time; only the first one is reported in any case since at least one shall be available.
         /// To configure all <paramref name="maxTasks"/> return always <see langword="false"/>.</remarks>
-        bool TaskConfigs(int currentTask, int maxTasks, IDictionary<string, string> config);
+        bool TaskConfigs(int currentTask, int maxTasks, IKNetTaskConfiguration config);
     }
     #endregion
 
@@ -134,10 +130,8 @@ namespace MASES.KNet.Connect
             return ExecuteOnRemote<T>("getContext");
         }
 
-        /// <inheritdoc cref="IKNetConnector.Properties"/>
-        public IReadOnlyDictionary<string, string> Properties { get; private set; }
-
         /// <inheritdoc cref="IKNetConnector.AllocateTask(long)"/>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public object AllocateTask(long taskId)
         {
             return taskDictionary.GetOrAdd(taskId, (id) =>
@@ -147,7 +141,7 @@ namespace MASES.KNet.Connect
                 return knetTask;
             });
         }
-
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         internal void DeallocateTask(long taskId)
         {
             taskDictionary.TryRemove(taskId, out var knetTask);
@@ -161,55 +155,75 @@ namespace MASES.KNet.Connect
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void Initialize(ConnectorContext ctx) => throw new NotImplementedException("Invoked in Java before any initialization.");
         /// <summary>
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void Initialize(ConnectorContext ctx, Java.Util.List<Map<Java.Lang.String, Java.Lang.String>> taskConfigs) => throw new NotImplementedException("Invoked in Java before any initialization.");
         /// <summary>
-        /// Public method used from Java to trigger <see cref="Start(Map{Java.Lang.String, Java.Lang.String})"/>
+        /// Public method used from Java to trigger <see cref="Start(Map{Java.Lang.String, object})"/>
         /// </summary>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void StartInternal()
         {
-            Map<Java.Lang.String, Java.Lang.String> props = DataToExchange<Map<Java.Lang.String, Java.Lang.String>>();
-            Start(props);
-            Properties = new System.Collections.Generic.Dictionary<string, string>(props.ToNetDictiony<string, string, Java.Lang.String, Java.Lang.String>());
-            Start(Properties);
+            try
+            {
+                Map<Java.Lang.String, object> props = DataToExchange<Map<Java.Lang.String, object>>();
+                Start(props);
+                Properties = new KNetConnectConfiguration(props);
+                Start(Properties);
+            }
+            catch (System.Exception e)
+            {
+                LogError($"StartInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Local version with a different signature</exception>
-        public virtual void Start(Map<Java.Lang.String, Java.Lang.String> props)
+        public virtual void Start(Map<Java.Lang.String, object> props)
         {
 
         }
 
-        /// <inheritdoc cref="IKNetConnector.Start(IReadOnlyDictionary{string, string})"/>
-        public abstract void Start(IReadOnlyDictionary<string, string> props);
+        /// <inheritdoc cref="IKNetConnector.Start(IKNetConnectConfiguration)"/>
+        public abstract void Start(IKNetConnectConfiguration configuration);
         /// <summary>
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException"></exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void Reconfigure(Map<Java.Lang.String, Java.Lang.String> props) => throw new NotImplementedException("Invoked in Java before any initialization.");
         /// <summary>
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public Class TaskClass() => throw new NotImplementedException("Invoked in Java before any initialization.");
         /// <summary>
-        /// Public method used from Java to trigger <see cref="TaskConfigs(int, int, IDictionary{string, string})"/>
+        /// Public method used from Java to trigger <see cref="TaskConfigs(int, int, IKNetTaskConfiguration)"/>
         /// </summary>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public bool TaskConfigsInternal(int currentTask, int maxTasks)
         {
-            Map<Java.Lang.String, Java.Lang.String> props = DataToExchange<Map<Java.Lang.String, Java.Lang.String>>();
-            return TaskConfigs(currentTask, maxTasks, props);
+            try
+            {
+                Map<Java.Lang.String, Java.Lang.String> props = DataToExchange<Map<Java.Lang.String, Java.Lang.String>>();
+                return TaskConfigs(currentTask, maxTasks, props);
+            }
+            catch (System.Exception e)
+            {
+                LogError($"TaskConfigsInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
-        /// Direct implementation can be used instead of <see cref="TaskConfigs(int, int, IDictionary{string, string})"/>
+        /// Direct implementation can be used instead of <see cref="TaskConfigs(int, int, IKNetTaskConfiguration)"/>
         /// </summary>
         /// <param name="currentTask"></param>
         /// <param name="maxTasks"></param>
@@ -217,8 +231,8 @@ namespace MASES.KNet.Connect
         /// <returns></returns>
         public virtual bool TaskConfigs(int currentTask, int maxTasks, Map<Java.Lang.String, Java.Lang.String> props)
         {
-            System.Collections.Generic.Dictionary<string, string> dict = new System.Collections.Generic.Dictionary<string, string>(props.ToNetDictiony<string, string, Java.Lang.String, Java.Lang.String>());
-            bool retVal = TaskConfigs(currentTask, maxTasks, dict);
+            var dict = new System.Collections.Generic.Dictionary<string, string>(props.ToNetDictiony<string, string, Java.Lang.String, Java.Lang.String>());
+            bool retVal = TaskConfigs(currentTask, maxTasks, new KNetTaskConfiguration(dict));
             props.Clear();
             foreach (var item in dict)
             {
@@ -227,12 +241,13 @@ namespace MASES.KNet.Connect
             return retVal;
         }
 
-        /// <inheritdoc cref="IKNetConnector.TaskConfigs(int, int, IDictionary{string, string})"/>
-        public abstract bool TaskConfigs(int currentTask, int maxTasks, IDictionary<string, string> config);
+        /// <inheritdoc cref="IKNetConnector.TaskConfigs(int, int, IKNetTaskConfiguration)"/>
+        public abstract bool TaskConfigs(int currentTask, int maxTasks, IKNetTaskConfiguration config);
         /// <summary>
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked using the other signature</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public Java.Util.List<Map<Java.Lang.String, Java.Lang.String>> TaskConfigs(int maxTasks) => throw new NotImplementedException("Invoked using the other signature.");
         /// <summary>
         /// Public method used from Java to trigger <see cref="Stop"/>
@@ -240,7 +255,15 @@ namespace MASES.KNet.Connect
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void StopInternal()
         {
-            Stop();
+            try
+            {
+                Stop();
+            }
+            catch (System.Exception e)
+            {
+                LogError($"StopInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Implement the method to execute the stop action
@@ -250,16 +273,19 @@ namespace MASES.KNet.Connect
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public Config Validate(Map<Java.Lang.String, Java.Lang.String> connectorConfigs) => throw new NotImplementedException("Invoked in Java before any initialization.");
         /// <summary>
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public ConfigDef Config() => throw new NotImplementedException("Invoked in Java before any initialization.");
         /// <summary>
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] 
         public string Version() => throw new NotImplementedException("Invoked in Java before any initialization.");
     }
     #endregion

--- a/src/net/KNet/Specific/Connect/KNetSinkConnector.cs
+++ b/src/net/KNet/Specific/Connect/KNetSinkConnector.cs
@@ -64,7 +64,15 @@ namespace MASES.KNet.Connect
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public bool AlterOffsetsInternal(Map<Java.Lang.String, Java.Lang.String> connectorConfig, Map<Org.Apache.Kafka.Common.TopicPartition, Long> offsets)
         {
-            return AlterOffsets(connectorConfig, offsets);
+            try
+            {
+                return AlterOffsets(connectorConfig, offsets);
+            }
+            catch (System.Exception e)
+            {
+                LogError($"AlterOffsetsInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Invoked when users request to manually alter/reset the offsets for this connector via the Connect worker's REST API. Connectors that manage offsets externally can propagate offset changes to their external system in this method. 
@@ -78,7 +86,7 @@ namespace MASES.KNet.Connect
         /// <returns>whether this method has been overridden by the connector; the default implementation returns <see langword="false"/>, and all other implementations (that do not unconditionally throw exceptions) should return <see langword="true"/></returns>
         /// <remarks>User requests to alter/reset offsets will be handled by the Connect runtime and will be reflected in the offsets for this connector's consumer group.
         /// Note that altering/resetting offsets is expected to be an idempotent operation and this method should be able to handle being called more than once with the same arguments (which could occur if a user retries the request due to a failure in altering the consumer group offsets, for example).
-        /// Similar to validate, this method may be called by the runtime before the <see cref="KNetConnector.Start(System.Collections.Generic.IReadOnlyDictionary{string, string})"/> method is invoked.</remarks>
+        /// Similar to validate, this method may be called by the runtime before the <see cref="KNetConnector.Start(IKNetConnectConfiguration)"/> method is invoked.</remarks>
         public virtual bool AlterOffsets(Map<Java.Lang.String, Java.Lang.String> connectorConfig, Map<Org.Apache.Kafka.Common.TopicPartition, Long> offsets)
         {
             return false;

--- a/src/net/KNet/Specific/Connect/KNetSinkTask.cs
+++ b/src/net/KNet/Specific/Connect/KNetSinkTask.cs
@@ -71,9 +71,17 @@ namespace MASES.KNet.Connect
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void PutInternal()
         {
-            Collection<SinkRecord> collection = DataToExchange<Collection<SinkRecord>>();
-            collection = collection.WithPrefetch(UsePrefetch).WithThread(UseThread, ThreadPriority);
-            Put(collection);
+            try
+            {
+                Collection<SinkRecord> collection = DataToExchange<Collection<SinkRecord>>();
+                collection = collection.WithPrefetch(UsePrefetch).WithThread(UseThread, ThreadPriority);
+                Put(collection);
+            }
+            catch (System.Exception e)
+            {
+                LogError($"PutInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Implement the method to execute the Put action

--- a/src/net/KNet/Specific/Connect/KNetSourceConnector.cs
+++ b/src/net/KNet/Specific/Connect/KNetSourceConnector.cs
@@ -97,7 +97,15 @@ namespace MASES.KNet.Connect
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public bool AlterOffsetsInternal(Map<Java.Lang.String, Java.Lang.String> connectorConfig, Map<Map<Java.Lang.String, object>, Map<Java.Lang.String, object>> offsets)
         {
-            return AlterOffsets(connectorConfig, offsets);
+            try
+            {
+                return AlterOffsets(connectorConfig, offsets);
+            }
+            catch (System.Exception e)
+            {
+                LogError($"AlterOffsetsInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Invoked when users request to manually alter/reset the offsets for this connector via the Connect worker's REST API. Connectors that manage offsets externally can propagate offset changes to their external system in this method. 
@@ -112,7 +120,7 @@ namespace MASES.KNet.Connect
         /// <returns>whether this method has been overridden by the connector; the default implementation returns <see langword="false"/>, and all other implementations (that do not unconditionally throw exceptions) should return <see langword="true"/></returns>
         /// <remarks>User requests to alter/reset offsets will be handled by the Connect runtime and will be reflected in the offsets returned by any OffsetStorageReader instances provided to this connector and its tasks.
         /// Note that altering/resetting offsets is expected to be an idempotent operation and this method should be able to handle being called more than once with the same arguments (which could occur if a user retries the request due to a failure in writing the new offsets to the offsets store, for example).
-        /// Similar to validate, this method may be called by the runtime before the <see cref="KNetConnector.Start(System.Collections.Generic.IReadOnlyDictionary{string, string})"/>> method is invoked.</remarks>
+        /// Similar to validate, this method may be called by the runtime before the <see cref="KNetConnector.Start(IKNetConnectConfiguration)"/>> method is invoked.</remarks>
         public virtual bool AlterOffsets(Map<Java.Lang.String, Java.Lang.String> connectorConfig, Map<Map<Java.Lang.String, object>, Map<Java.Lang.String, object>> offsets)
         {
             return false;

--- a/src/net/KNet/Specific/Connect/KNetSourceTask.cs
+++ b/src/net/KNet/Specific/Connect/KNetSourceTask.cs
@@ -30,7 +30,7 @@ namespace MASES.KNet.Connect
     /// <summary>
     /// Helper interface for <see cref="KNetSourceTask{TTask}"/>
     /// </summary>
-    public interface IKNetSourceTask: IKNetTask
+    public interface IKNetSourceTask : IKNetTask
     {
         /// <summary>
         /// If <see cref="UseOnlyAsync"/> is <see langword="true"/>, each <paramref name="record"/> is accumulated in a list outside the scope of <see cref="KNetSourceTask{TTask}.Poll"/> invocation.
@@ -41,7 +41,7 @@ namespace MASES.KNet.Connect
         void PushRecordAsync(SourceRecord record);
 
         /// <summary>
-        /// Implement the method to declare if out-of-sync feature will be used: it will be set once within <see cref="KNetSourceTask{TTask}"/> invocation of <see cref="KNetTask.Start(System.Collections.Generic.IReadOnlyDictionary{string, string})"/>
+        /// Implement the method to declare if out-of-sync feature will be used: it will be set once within <see cref="KNetSourceTask{TTask}"/> invocation of <see cref="KNetTask.Start(IKNetConnectConfiguration)"/>
         /// </summary>
         /// <returns>Returning <see langword="true"/> will use the out-of-sync feature, otherwise returning <see langword="false"/> the feature is disabled which is the default behavior.</returns>
         /// <remarks>Be aware that returning <see langword="true"/> from this method will be mutually exclusive between the usage of <see cref="PushRecordAsync(SourceRecord)"/> and invocation of <see cref="KNetSourceTask{TTask}.Poll"/></remarks>
@@ -77,7 +77,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKey, TValue>(string topic, int? partition, Schema valueSchema, TValue value,
                                                Map<Java.Lang.String, object> sourcePartition = null, Map<Java.Lang.String, object> sourceOffset = null);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type of the key to be inserted in Kafka</typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -120,7 +120,7 @@ namespace MASES.KNet.Connect
                                                Map<Java.Lang.String, object> sourcePartition = null, Map<Java.Lang.String, object> sourceOffset = null);
 
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type of the key to be inserted in Kafka</typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -165,7 +165,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKey, TValue>(string topic, Schema keySchema, TKey key, Schema valueSchema, TValue value,
                                                Map<Java.Lang.String, object> sourcePartition = null, Map<Java.Lang.String, object> sourceOffset = null);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type of the key to be inserted in Kafka</typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -213,7 +213,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKey, TValue>(string topic, int? partition, Schema keySchema, TKey key, Schema valueSchema, TValue value,
                                                Map<Java.Lang.String, object> sourcePartition = null, Map<Java.Lang.String, object> sourceOffset = null);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type of the key to be inserted in Kafka</typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -257,7 +257,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TValue>(string topic, Schema valueSchema, TValue value, DateTime timestamp,
                                          Map<Java.Lang.String, object> sourcePartition = null, Map<Java.Lang.String, object> sourceOffset = null);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
         /// <param name="topic">The name of the topic; may be null</param>
@@ -300,7 +300,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TValue>(string topic, int? partition, Schema valueSchema, TValue value, DateTime timestamp,
                                          Map<Java.Lang.String, object> sourcePartition = null, Map<Java.Lang.String, object> sourceOffset = null);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
         /// <param name="topic">The name of the topic; may be null</param>
@@ -350,7 +350,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKey, TValue>(string topic, int? partition, Schema keySchema, TKey key, Schema valueSchema, TValue value, DateTime timestamp,
                                                Map<Java.Lang.String, object> sourcePartition = null, Map<Java.Lang.String, object> sourceOffset = null);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type of the key to be inserted in Kafka</typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -405,7 +405,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKey, TValue>(string topic, int? partition, Schema keySchema, TKey key, Schema valueSchema, TValue value, DateTime timestamp, Headers headers,
                                                Map<Java.Lang.String, object> sourcePartition = null, Map<Java.Lang.String, object> sourceOffset = null);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type of the key to be inserted in Kafka</typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -459,7 +459,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKeySource, TOffset, TKey, TValue>(Map<Java.Lang.String, TKeySource> sourcePartition, Map<Java.Lang.String, TOffset> sourceOffset,
                                                                     string topic, int? partition, Schema valueSchema, TValue value);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type of the key to be inserted in Kafka</typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -510,7 +510,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKeySource, TOffset, TKey, TValue>(Map<Java.Lang.String, TKeySource> sourcePartition, Map<Java.Lang.String, TOffset> sourceOffset,
                                                                     string topic, Schema valueSchema, TValue value);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type within <see cref="Map{String, TKey}"/> of <paramref name="sourcePartition"/></typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -564,7 +564,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKeySource, TOffset, TKey, TValue>(Map<Java.Lang.String, TKeySource> sourcePartition, Map<Java.Lang.String, TOffset> sourceOffset,
                                                                     string topic, Schema keySchema, TKey key, Schema valueSchema, TValue value);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type within <see cref="Map{String, TKey}"/> of <paramref name="sourcePartition"/></typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -622,7 +622,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKeySource, TOffset, TKey, TValue>(Map<Java.Lang.String, TKeySource> sourcePartition, Map<Java.Lang.String, TOffset> sourceOffset,
                                                                     string topic, int? partition, Schema keySchema, TKey key, Schema valueSchema, TValue value);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type within <see cref="Map{String, TKey}"/> of <paramref name="sourcePartition"/></typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -675,7 +675,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKeySource, TOffset, TValue>(Map<Java.Lang.String, TKeySource> sourcePartition, Map<Java.Lang.String, TOffset> sourceOffset,
                                                               string topic, Schema valueSchema, TValue value, DateTime timestamp);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
         /// <typeparam name="TKeySource">The type within <see cref="Map{String, TKeySource}"/> of <paramref name="sourcePartition"/></typeparam>
@@ -727,7 +727,7 @@ namespace MASES.KNet.Connect
         void CreateAndPushRecord<TKeySource, TOffset, TValue>(Map<Java.Lang.String, TKeySource> sourcePartition, Map<Java.Lang.String, TOffset> sourceOffset,
                                                               string topic, int? partition, Schema valueSchema, TValue value, DateTime timestamp);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
         /// <typeparam name="TKeySource">The type within <see cref="Map{String, TKeySource}"/> of <paramref name="sourcePartition"/></typeparam>
@@ -741,7 +741,7 @@ namespace MASES.KNet.Connect
         /// <param name="timestamp">The timestamp; may be null</param>
         /// <remarks>These values can have arbitrary structure and should be represented using Org.Apache.Kafka.Connect.Data.* objects (or primitive values). 
         /// For example, a database connector might specify the <paramref name="sourcePartition"/> as a record containing { "db": "database_name", "table": "table_name"} and the <paramref name="sourceOffset"/> as a <see langword="long"/> containing the timestamp of the row.</remarks>
-        void CreateAndPushRecordAsync<TKeySource, TOffset, TValue>(Map<Java.Lang.String, TKeySource> sourcePartition, Map<Java.Lang.String, TOffset> sourceOffset, 
+        void CreateAndPushRecordAsync<TKeySource, TOffset, TValue>(Map<Java.Lang.String, TKeySource> sourcePartition, Map<Java.Lang.String, TOffset> sourceOffset,
                                                                    string topic, int? partition, Schema valueSchema, TValue value, DateTime timestamp);
 
         /// <summary>
@@ -792,7 +792,7 @@ namespace MASES.KNet.Connect
                                                                     Schema valueSchema, TValue value,
                                                                     DateTime timestamp);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type within <see cref="Map{String, TKey}"/> of <paramref name="sourcePartition"/></typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -865,7 +865,7 @@ namespace MASES.KNet.Connect
                                                                     Schema valueSchema, TValue value,
                                                                     DateTime timestamp, Headers headers);
         /// <summary>
-        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="Poll"/> to return back the list of <see cref="SourceRecord"/>
+        /// Creates a new <see cref="SourceRecord{TKeySource, TOffset, TKey, TValue}"/> and push it to JVM in async mode using <see cref="PushRecordAsync(SourceRecord)"/>, i.e. without waiting the invocation of <see cref="KNetSourceTask{T}.Poll"/> to return back the list of <see cref="SourceRecord"/>
         /// </summary>
         /// <typeparam name="TKey">The type within <see cref="Map{String, TKey}"/> of <paramref name="sourcePartition"/></typeparam>
         /// <typeparam name="TValue">The type of value to be inserted in Kafka</typeparam>
@@ -976,19 +976,27 @@ namespace MASES.KNet.Connect
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void PollInternal()
         {
-            _arrayList = DataToExchange<ArrayList<SourceRecord>>();
             try
             {
-                var result = Poll();
-                if (result != null)
+                _arrayList = DataToExchange<ArrayList<SourceRecord>>();
+                try
                 {
-                    foreach (var record in result)
+                    var result = Poll();
+                    if (result != null)
                     {
-                        _arrayList.Add(record);
+                        foreach (var record in result)
+                        {
+                            _arrayList.Add(record);
+                        }
                     }
                 }
+                finally { _arrayList = null; }
             }
-            finally { _arrayList = null; }
+            catch (System.Exception e)
+            {
+                LogError($"PollInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Implement the method to execute the Poll action

--- a/src/net/KNet/Specific/Connect/KNetTask.cs
+++ b/src/net/KNet/Specific/Connect/KNetTask.cs
@@ -16,16 +16,124 @@
 *  Refer to LICENSE for more information.
 */
 
+using Java.Lang;
 using Java.Util;
 using MASES.JCOBridge.C2JBridge;
 using MASES.JCOBridge.C2JBridge.JVMInterop;
 using MASES.JNet.Specific.Extensions;
+using Org.Apache.Kafka.Common.Config.Types;
 using Org.Apache.Kafka.Connect.Connector;
 using System;
 using System.Collections.Generic;
 
 namespace MASES.KNet.Connect
 {
+    #region IKNetConnectConfiguration
+    /// <summary>
+    /// Interface to simplify access configuration information
+    /// </summary>
+    public interface IKNetTaskConfiguration
+    {
+        /// <summary>
+        /// Adds <see langword="short"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <param name="value">The <see langword="short"/> value associated to <paramref name="key"/></param>
+        void Add(string key, short value);
+        /// <summary>
+        /// Adds <see langword="int"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <param name="value">The <see langword="int"/> value associated to <paramref name="key"/></param>
+        void Add(string key, int value);
+        /// <summary>
+        /// Adds <see langword="long"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <param name="value">The <see langword="long"/> value associated to <paramref name="key"/></param>
+        void Add(string key, long value);
+        /// <summary>
+        /// Adds <see langword="double"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <param name="value">The <see langword="double"/> value associated to <paramref name="key"/></param>
+        void Add(string key, double value);
+        /// <summary>
+        /// Adds <see langword="bool"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <param name="value">The <see langword="bool"/> value associated to <paramref name="key"/></param>
+        void Add(string key, bool value);
+        /// <summary>
+        /// Adds <see langword="string"/> associated to <paramref name="key"/>
+        /// </summary>
+        /// <param name="key">The key to return</param>
+        /// <param name="value">The <see langword="string"/> value associated to <paramref name="key"/></param>
+        void Add(string key, string value);
+        /// <summary>
+        /// Adds all values in <paramref name="values"/>
+        /// </summary>
+        /// <param name="values">The <see cref="IEnumerable{T}"/> containing key-value information</param>
+        void Add(IEnumerable<KeyValuePair<string, object>> values);
+    }
+
+    #endregion
+
+    #region KNetTaskConfiguration
+    /// <summary>
+    /// Interface to simplify access configuration information
+    /// </summary>
+    class KNetTaskConfiguration : IKNetTaskConfiguration
+    {
+        readonly System.Collections.Generic.IDictionary<string, string> _dict;
+
+        public KNetTaskConfiguration(System.Collections.Generic.IDictionary<string, string> dict)
+        {
+            _dict = dict;
+        }
+
+        /// <inheritdoc/>
+        public void Add(string key, short value)
+        {
+            _dict.Add(key, value.ToString());
+        }
+        /// <inheritdoc/>
+        public void Add(string key, int value)
+        {
+            _dict.Add(key, value.ToString());
+        }
+        /// <inheritdoc/>
+        public void Add(string key, long value)
+        {
+            _dict.Add(key, value.ToString());
+        }
+        /// <inheritdoc/>
+        public void Add(string key, double value)
+        {
+            _dict.Add(key, value.ToString());
+        }
+        /// <inheritdoc/>
+        public void Add(string key, bool value)
+        {
+            _dict.Add(key, value.ToString());
+        }
+        /// <inheritdoc/>
+        public void Add(string key, string value)
+        {
+            _dict.Add(key, value);
+        }
+        /// <inheritdoc/>
+        public void Add(IEnumerable<KeyValuePair<string, object>> values)
+        {
+            foreach (var item in values)
+            {
+                _dict.Add(item.Key, item.Value.ToString());
+            }
+        }
+    }
+
+    #endregion
+
     #region ITask
     /// <summary>
     /// Task interface for KNet Connect SDK
@@ -57,10 +165,6 @@ namespace MASES.KNet.Connect
     public interface IKNetTask : ITask, IKNetCommon
     {
         /// <summary>
-        /// The properties retrieved from <see cref="KNetTask.StartInternal"/>
-        /// </summary>
-        IReadOnlyDictionary<string, string> Properties { get; }
-        /// <summary>
         /// The associated <see cref="IConnector"/>
         /// </summary>
         IKNetConnector Connector { get; }
@@ -71,8 +175,8 @@ namespace MASES.KNet.Connect
         /// <summary>
         /// Implement the method to execute the start action
         /// </summary>
-        /// <param name="props">The set of properties returned from Apache Kafka Connect framework: the <see cref="IReadOnlyDictionary{TKey, TValue}"/> contains the info from <see cref="KNetConnector.TaskConfigs(int, IDictionary{string, string})"/>.</param>
-        void Start(IReadOnlyDictionary<string, string> props);
+        /// <param name="props">The <see cref="IKNetConnectConfiguration"/> to access the properties returned from Apache Kafka Connect framework: the <see cref="IKNetCommon.Properties"/> contains the info from <see cref="KNetConnector.TaskConfigs(int, int, IKNetTaskConfiguration)"/>.</param>
+        void Start(IKNetConnectConfiguration props);
     }
     #endregion
 
@@ -107,8 +211,6 @@ namespace MASES.KNet.Connect
             return ExecuteOnRemote<T>("getContext");
         }
 
-        /// <inheritdoc cref="IKNetTask.Properties"/>
-        public IReadOnlyDictionary<string, string> Properties { get; private set; }
         /// <inheritdoc cref="IKNetTask.Connector"/>
         public IKNetConnector Connector => _connector;
         /// <inheritdoc cref="IKNetTask.TaskId"/>
@@ -123,9 +225,17 @@ namespace MASES.KNet.Connect
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void StartInternal()
         {
-            Map<Java.Lang.String, Java.Lang.String> props = DataToExchange<Map<Java.Lang.String, Java.Lang.String>>();
-            Properties = new System.Collections.Generic.Dictionary<string, string>(props.ToNetDictiony<string, string, Java.Lang.String, Java.Lang.String>());
-            Start(Properties);
+            try
+            {
+                Map<Java.Lang.String, Java.Lang.String> props = DataToExchange<Map<Java.Lang.String, Java.Lang.String>>();
+                Properties = new KNetConnectConfiguration(props);
+                Start(Properties);
+            }
+            catch (System.Exception e)
+            {
+                LogError($"StartInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Not implemented
@@ -133,16 +243,24 @@ namespace MASES.KNet.Connect
         /// <exception cref="NotImplementedException">Local version with a different signature</exception>
         public void Start(Map<Java.Lang.String, Java.Lang.String> props) => throw new NotImplementedException("Local version with a different signature");
 
-        /// <inheritdoc cref="IKNetTask.Start(IReadOnlyDictionary{string, string})"/>
-        public abstract void Start(IReadOnlyDictionary<string, string> props);
+        /// <inheritdoc cref="IKNetTask.Start(IKNetConnectConfiguration)"/>
+        public abstract void Start(IKNetConnectConfiguration props);
         /// <summary>
         /// Public method used from Java to trigger <see cref="Stop"/>
         /// </summary>
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void StopInternal()
         {
-            Stop();
-            _connector.DeallocateTask(_taskId);
+            try
+            {
+                Stop();
+                _connector.DeallocateTask(_taskId);
+            }
+            catch (System.Exception e)
+            {
+                LogError($"StopInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Implement the method to execute the stop action
@@ -154,7 +272,15 @@ namespace MASES.KNet.Connect
         [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public object VersionInternal()
         {
-            return Version();
+            try
+            {
+                return Version();
+            }
+            catch (System.Exception e)
+            {
+                LogError($"VersionInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Implement the method to execute the version action

--- a/src/net/KNet/Specific/Connect/Transforms/KNetTransformation.cs
+++ b/src/net/KNet/Specific/Connect/Transforms/KNetTransformation.cs
@@ -64,10 +64,6 @@ namespace MASES.KNet.Connect.Transforms
     public interface IKNetTransformation : ITransformation
     {
         /// <summary>
-        /// The properties retrieved from <see cref="KNetTransformation.Configure(Map{Java.Lang.String, object})"/>
-        /// </summary>
-        IReadOnlyDictionary<string, object> Properties { get; }
-        /// <summary>
         /// Implements the behavior of <see cref="ITransformation.Apply(ConnectRecord)"/> for <paramref name="record"/>
         /// </summary>
         /// <param name="record">The <see cref="SourceRecord"/> to test</param>
@@ -84,17 +80,14 @@ namespace MASES.KNet.Connect.Transforms
         /// <summary>
         /// Implement the method to execute the start action
         /// </summary>
-        /// <param name="props">The set of properties returned from Apache Kafka Connect framework: the <see cref="IReadOnlyDictionary{TKey, TValue}"/> contains the same info from configuration file.</param>
-        void Configure(IReadOnlyDictionary<string, object> props);
+        /// <param name="configuration">The <see cref="IKNetConnectConfiguration"/> to access the properties returned from Apache Kafka Connect framework: the <see cref="IKNetCommon.Properties"/> contains the same info from configuration file.</param>
+        void Configure(IKNetConnectConfiguration configuration);
     }
     /// <summary>
     /// The generic class which is the base of all transformations in .NET
     /// </summary>
     public abstract class KNetTransformation : KNetCommon, IKNetTransformation
     {
-        /// <inheritdoc cref="IKNetTransformation.Properties"/>
-        public IReadOnlyDictionary<string, object> Properties { get; private set; }
-
         /// <summary>
         /// Set the <see cref="ReflectedRemoteObjectClassName"/> of the connector to a fixed value
         /// </summary>
@@ -103,13 +96,21 @@ namespace MASES.KNet.Connect.Transforms
         /// <summary>
         /// Public method used from Java to trigger <see cref="Apply(ConnectRecord)"/>
         /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void ApplyInternal()
         {
-            var record = DataToExchange<ConnectRecord>();
-            var record1 = Apply(record);
-            DataToExchange(record1);
+            try
+            {
+                var record = DataToExchange<ConnectRecord>();
+                var record1 = Apply(record);
+                DataToExchange(record1);
+            }
+            catch (System.Exception e)
+            {
+                LogError($"ApplyInternal failed with {e}");
+                throw;
+            }
         }
-
 
         /// <inheritdoc cref="ITransformation.Apply(ConnectRecord)"/>
         public virtual ConnectRecord Apply(ConnectRecord record)
@@ -145,17 +146,21 @@ namespace MASES.KNet.Connect.Transforms
         /// <summary>
         /// Public method used from Java to trigger <see cref="Configure(Map{Java.Lang.String, object})"/>
         /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void ConfigureInternal()
         {
-            Map<Java.Lang.String, object> props = DataToExchange<Map<Java.Lang.String, object>>();
-            Configure(props);
-            var dict = new System.Collections.Generic.Dictionary<string, object>();
-            foreach (var item in props.EntrySet())
+            try
             {
-                dict.Add(item.Key, item.Value);
+                Map<Java.Lang.String, object> props = DataToExchange<Map<Java.Lang.String, object>>();
+                Configure(props);
+                Properties = new KNetConnectConfiguration(props);
+                Configure(Properties);
             }
-            Properties = dict;
-            Configure(Properties);
+            catch (System.Exception e)
+            {
+                LogError($"ConfigureInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Not implemented
@@ -166,15 +171,23 @@ namespace MASES.KNet.Connect.Transforms
 
         }
 
-        /// <inheritdoc cref="IKNetTransformation.Configure(IReadOnlyDictionary{string, object})"/>
-        public abstract void Configure(IReadOnlyDictionary<string, object> props);
+        /// <inheritdoc cref="IKNetTransformation.Configure(IKNetConnectConfiguration)"/>
+        public abstract void Configure(IKNetConnectConfiguration configuration);
 
         /// <summary>
         /// Public method used from Java to trigger <see cref="Close"/>
         /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void CloseInternal()
         {
-            Close();
+            try
+            {
+                Close();
+            }
+            catch (System.Exception e)
+            {
+                LogError($"CloseInternal failed with {e}");
+            }
             try
             {
                 Unregister();
@@ -189,11 +202,13 @@ namespace MASES.KNet.Connect.Transforms
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public ConfigDef Config() => throw new NotImplementedException("Invoked in Java before any initialization.");
         /// <summary>
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public string Version() => throw new NotImplementedException("Invoked in Java before any initialization.");
     }
 }

--- a/src/net/KNet/Specific/Connect/Transforms/Predicates/KNetPredicate.cs
+++ b/src/net/KNet/Specific/Connect/Transforms/Predicates/KNetPredicate.cs
@@ -68,10 +68,6 @@ namespace MASES.KNet.Connect.Transforms.Predicates
     public interface IKNetPredicate : IPredicate
     {
         /// <summary>
-        /// The properties retrieved from <see cref="KNetPredicate.Configure(Map{Java.Lang.String, object})"/>
-        /// </summary>
-        IReadOnlyDictionary<string, object> Properties { get; }
-        /// <summary>
         /// Implements the behavior of <see cref="IPredicate.Test(ConnectRecord)"/> for <paramref name="record"/>
         /// </summary>
         /// <param name="record">The <see cref="SourceRecord"/> to test</param>
@@ -88,17 +84,14 @@ namespace MASES.KNet.Connect.Transforms.Predicates
         /// <summary>
         /// Implement the method to execute the start action
         /// </summary>
-        /// <param name="props">The set of properties returned from Apache Kafka Connect framework: the <see cref="IReadOnlyDictionary{TKey, TValue}"/> contains the same info from configuration file.</param>
-        void Configure(IReadOnlyDictionary<string, object> props);
+        /// <param name="configuration">The <see cref="IKNetConnectConfiguration"/> to access the properties returned from Apache Kafka Connect framework: the <see cref="IKNetCommon.Properties"/> contains the same info from configuration file.</param>
+        void Configure(IKNetConnectConfiguration configuration);
     }
     /// <summary>
     /// The generic class which is the base of all predicates in .NET
     /// </summary>
     public abstract class KNetPredicate : KNetCommon, IKNetPredicate
     {
-        /// <inheritdoc cref="IKNetPredicate.Properties"/>
-        public IReadOnlyDictionary<string, object> Properties { get; private set; }
-
         /// <summary>
         /// Set the <see cref="ReflectedRemoteObjectClassName"/> of the connector to a fixed value
         /// </summary>
@@ -107,12 +100,21 @@ namespace MASES.KNet.Connect.Transforms.Predicates
         /// <summary>
         /// Public method used from Java to trigger <see cref="Test(ConnectRecord)"/>
         /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public bool TestInternal()
         {
-            var record = DataToExchange<ConnectRecord>();
-            return Test(record);
+            try
+            {
+                var record = DataToExchange<ConnectRecord>();
+                return Test(record);
+            }
+            catch (System.Exception e)
+            {
+                LogError($"TestInternal failed with {e}");
+                throw;
+            }
         }
-        
+
         /// <inheritdoc cref="IPredicate.Test(ConnectRecord)"/>
         public virtual bool Test(ConnectRecord record)
         {
@@ -147,9 +149,18 @@ namespace MASES.KNet.Connect.Transforms.Predicates
         /// <summary>
         /// Public method used from Java to trigger <see cref="ToStringInternal"/>
         /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public string ToStringInternal()
         {
-            return ToStringPredicate();
+            try
+            {
+                return ToStringPredicate();
+            }
+            catch (System.Exception e)
+            {
+                LogError($"ToStringInternal failed with {e}");
+                throw;
+            }
         }
 
         /// <inheritdoc cref="IPredicate.ToStringPredicate"/>
@@ -158,17 +169,21 @@ namespace MASES.KNet.Connect.Transforms.Predicates
         /// <summary>
         /// Public method used from Java to trigger <see cref="Configure(Map{Java.Lang.String, object})"/>
         /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void ConfigureInternal()
         {
-            Map<Java.Lang.String, object> props = DataToExchange<Map<Java.Lang.String, object>>();
-            Configure(props);
-            var dict = new System.Collections.Generic.Dictionary<string, object>();
-            foreach (var item in props.EntrySet())
+            try
             {
-                dict.Add(item.Key, item.Value);
+                Map<Java.Lang.String, object> props = DataToExchange<Map<Java.Lang.String, object>>();
+                Configure(props);
+                Properties = new KNetConnectConfiguration(props);
+                Configure(Properties);
             }
-            Properties = dict;
-            Configure(Properties);
+            catch (System.Exception e)
+            {
+                LogError($"ConfigureInternal failed with {e}");
+                throw;
+            }
         }
         /// <summary>
         /// Not implemented
@@ -179,15 +194,24 @@ namespace MASES.KNet.Connect.Transforms.Predicates
 
         }
 
-        /// <inheritdoc cref="IKNetPredicate.Configure(IReadOnlyDictionary{string, object})"/>
-        public abstract void Configure(IReadOnlyDictionary<string, object> props);
+        /// <inheritdoc cref="IKNetPredicate.Configure(IKNetConnectConfiguration)"/>
+        public abstract void Configure(IKNetConnectConfiguration configuration);
 
         /// <summary>
         /// Public method used from Java to trigger <see cref="Close"/>
         /// </summary>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public void CloseInternal()
         {
-            Close();
+            try
+            {
+                Close();
+            }
+            catch (System.Exception e)
+            {
+                LogError($"CloseInternal failed with {e}");
+            }
+
             try
             {
                 Unregister();
@@ -202,11 +226,13 @@ namespace MASES.KNet.Connect.Transforms.Predicates
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public ConfigDef Config() => throw new NotImplementedException("Invoked in Java before any initialization.");
         /// <summary>
         /// Not implemented
         /// </summary>
         /// <exception cref="NotImplementedException">Invoked in Java before any initialization</exception>
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public string Version() => throw new NotImplementedException("Invoked in Java before any initialization.");
     }
 }

--- a/src/net/KNet/Specific/Serialization/KNetSerialization.cs
+++ b/src/net/KNet/Specific/Serialization/KNetSerialization.cs
@@ -327,7 +327,7 @@ namespace MASES.KNet.Serialization
         }
 
         /// <summary>
-        /// Serialize a <see cref="SerializationType.BooleanNulable"/>
+        /// Serialize a <see cref="SerializationType.NullableBoolean"/>
         /// </summary>
         public static byte[] SerializeBoolean(bool fallbackToKafka, string topic, bool? data)
         {

--- a/src/net/templates/templates/knetConnectSink/KNetConnectSink.cs
+++ b/src/net/templates/templates/knetConnectSink/KNetConnectSink.cs
@@ -7,7 +7,7 @@ namespace MASES.KNet.Template.KNetConnect
 {
     public class KNetConnectSink : KNetSinkConnector<KNetConnectSink, KNetConnectSinkTask>
     {
-        public override void Start(IReadOnlyDictionary<string, string> props)
+        public override void Start(IKNetConnectConfiguration props)
         {
             LogInfo($"KNetConnectSink Start");
             // starts the connector, the method receives the configuration properties
@@ -19,14 +19,14 @@ namespace MASES.KNet.Template.KNetConnect
             // stops the connector
         }
 
-        public override bool TaskConfigs(int index, int maxTasks, IDictionary<string, string> config)
+        public override bool TaskConfigs(int index, int maxTasks, IKNetTaskConfiguration config)
         {
             LogInfo($"Fill properties of task {index}");
             // fill in the properties for task configuration
             foreach (var item in Properties)
             {
                 LogInfo($"{item.Key}={item.Value}");
-                config.Add(item); // fill in all properties
+                config.Add(item.Key, item.Value?.ToString()); // fill in all properties
             }
             return false;
         }
@@ -45,7 +45,7 @@ namespace MASES.KNet.Template.KNetConnect
             }
         }
 
-        public override void Start(IReadOnlyDictionary<string, string> props)
+        public override void Start(IKNetConnectConfiguration props)
         {
             // starts the task with the configuration set from connector
             LogInfo($"KNetConnectSinkTask start");

--- a/src/net/templates/templates/knetConnectSource/KNetConnectSource.cs
+++ b/src/net/templates/templates/knetConnectSource/KNetConnectSource.cs
@@ -9,7 +9,7 @@ namespace MASES.KNet.Template.KNetConnect
 {
     public class KNetConnectSource : KNetSourceConnector<KNetConnectSource, KNetConnectSourceTask>
     {
-        public override void Start(IReadOnlyDictionary<string, string> props)
+        public override void Start(IKNetConnectConfiguration props)
         {
             LogInfo($"KNetConnectSource Start");
             // starts the connector, the method receives the configuration properties
@@ -21,7 +21,7 @@ namespace MASES.KNet.Template.KNetConnect
             // stops the connector
         }
 
-        public override bool TaskConfigs(int index, int maxTasks, IDictionary<string, string> config)
+        public override bool TaskConfigs(int index, int maxTasks, IKNetTaskConfiguration config)
         {
             // fill in the properties for task configuration
             LogInfo($"Fill properties of task {index}");
@@ -29,7 +29,7 @@ namespace MASES.KNet.Template.KNetConnect
             foreach (var item in Properties)
             {
                 LogInfo($"{item.Key}={item.Value}");
-                config.Add(item); // fill in all properties
+                config.Add(item.Key, item.Value?.ToString()); // fill in all properties
             }
 
             return false;
@@ -92,7 +92,7 @@ namespace MASES.KNet.Template.KNetConnect
             return records;
         }
 
-        public override void Start(IReadOnlyDictionary<string, string> props)
+        public override void Start(IKNetConnectConfiguration props)
         {
             // starts the task with the configuration set from connector
             // in this template we set only _topic local variables from configuration
@@ -100,7 +100,7 @@ namespace MASES.KNet.Template.KNetConnect
             foreach (var item in props)
             {
                 LogInfo($"Task config {item.Key}={item.Value}");
-                if (item.Key == "topic") _topic = item.Value;
+                if (item.Key == "topic") _topic = item.Value.ToString();
             }
         }
 

--- a/tests/net/Connect/KNetConnectTest/KNetConnectSink.cs
+++ b/tests/net/Connect/KNetConnectTest/KNetConnectSink.cs
@@ -24,7 +24,7 @@ namespace MASES.KNet.Connect.Test
 {
     public class KNetSinkTestConnector : KNetSinkConnector<KNetSinkTestConnector, KNetSinkTestTask>
     {
-        public override void Start(IReadOnlyDictionary<string, string> props)
+        public override void Start(IKNetConnectConfiguration props)
         {
             LogInfo($"KNetSinkTestConnector Start");
         }
@@ -34,14 +34,14 @@ namespace MASES.KNet.Connect.Test
             LogInfo($"KNetSinkTestConnector Stop");
         }
 
-        public override bool TaskConfigs(int index, int maxTasks, IDictionary<string, string> config)
+        public override bool TaskConfigs(int index, int maxTasks, IKNetTaskConfiguration config)
         {
             LogInfo($"Fill in task {index}");
 
             foreach (var item in Properties)
             {
                 LogInfo($"{item.Key}={item.Value}");
-                config.Add(item); // fill in all properties
+                config.Add(item.Key, item.Value?.ToString()); // fill in all properties
             }
 
             return false;
@@ -60,7 +60,7 @@ namespace MASES.KNet.Connect.Test
             }
         }
 
-        public override void Start(IReadOnlyDictionary<string, string> props)
+        public override void Start(IKNetConnectConfiguration props)
         {
             LogInfo($"KNetSinkTestTask start");
             foreach (var item in props)

--- a/tests/net/Connect/KNetConnectTest/KNetConnectSource.cs
+++ b/tests/net/Connect/KNetConnectTest/KNetConnectSource.cs
@@ -20,14 +20,13 @@ using Java.Util;
 using Org.Apache.Kafka.Connect.Data;
 using Org.Apache.Kafka.Connect.Source;
 using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace MASES.KNet.Connect.Test
 {
     public class KNetSourceTestConnector : KNetSourceConnector<KNetSourceTestConnector, KNetSourceTestTask>
     {
-        public override void Start(IReadOnlyDictionary<string, string> props)
+        public override void Start(IKNetConnectConfiguration props)
         {
             LogInfo($"KNetSourceTestConnector Start");
         }
@@ -37,14 +36,14 @@ namespace MASES.KNet.Connect.Test
             LogInfo($"KNetSourceTestConnector Stop");
         }
 
-        public override bool TaskConfigs(int index, int maxTasks, IDictionary<string, string> config)
+        public override bool TaskConfigs(int index, int maxTasks, IKNetTaskConfiguration config)
         {
             LogInfo($"Fill in task {index}");
 
             foreach (var item in Properties)
             {
                 LogInfo($"{item.Key}={item.Value}");
-                config.Add(item); // fill in all properties
+                config.Add(item.Key, item.Value?.ToString()); // fill in all properties
             }
 
             return false;
@@ -106,7 +105,7 @@ namespace MASES.KNet.Connect.Test
             return records;
         }
 
-        public override void Start(IReadOnlyDictionary<string, string> props)
+        public override void Start(IKNetConnectConfiguration props)
         {
             LogInfo($"KNetSourceTestTask start");
             foreach (var item in props)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Review KNet Connect SDK configuration
The configuration is reviewed to identify and propagate default values defined in JVM side. Adds a new IKNetCommonConfiguration to simplify the access to configuration properties and updates the signature of the methods to introduce the new behavior. Task configuration in Source/Sink connector wasn't changed since it is a pass-through between connector and tasks

* Updates KNetTask Start method adding support for string only configuration values

* Adds IKNetTaskConfiguration to support configuration management from tasks

* Potential fix for pull request finding 'Missed 'readonly' opportunity'

* Fix task data exchange

* Fix NullReferenceException and adds logs when methods fails reporting .NET info

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
