### PR TITLE
Dispose serialized/deserialized/local resources

### DIFF
--- a/.github/workflows/generateclasses.yaml
+++ b/.github/workflows/generateclasses.yaml
@@ -41,7 +41,7 @@ jobs:
       DOTNET_CreateDumpVerboseDiagnostics: 1
       DOTNET_EnableCrashReport: 1
       JCOBRIDGE_LicensePath: ${{ secrets.JCOBRIDGE_ENCODED_2_6_9 }}
-      JNet_Version: 2.6.9-rc93
+      JNet_Version: 2.6.9-rc94
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/src/net/KNet.Serialization.Json/JsonSerDes.cs
+++ b/src/net/KNet.Serialization.Json/JsonSerDes.cs
@@ -267,7 +267,7 @@ namespace MASES.KNet.Serialization.Json
                             return Newtonsoft.Json.JsonConvert.DeserializeObject<TData>(jsonStr, Options);
                         }
 #else
-                        return System.Text.Json.JsonSerializer.Deserialize<TData>(data.ToDirectBuffer().AsSpan(), Options)!;
+                        return System.Text.Json.JsonSerializer.Deserialize<TData>(data.AsSpan(), Options)!;
 #endif
                     }
                 }
@@ -508,7 +508,7 @@ namespace MASES.KNet.Serialization.Json
                             return Newtonsoft.Json.JsonConvert.DeserializeObject<TData>(jsonStr, Options);
                         }
 #else
-                        return System.Text.Json.JsonSerializer.Deserialize<TData>(data.ToDirectBuffer().AsSpan(), Options)!;
+                        return System.Text.Json.JsonSerializer.Deserialize<TData>(data.AsSpan(), Options)!;
 #endif
                     }
                 }

--- a/src/net/KNet.Serialization.Protobuf/ProtobufSerDes.cs
+++ b/src/net/KNet.Serialization.Protobuf/ProtobufSerDes.cs
@@ -174,7 +174,7 @@ namespace MASES.KNet.Serialization.Protobuf
                         using var stream = data.ToStream();
                         return _parser.ParseFrom(stream);
 #else
-                        return _parser.ParseFrom(data.ToDirectBuffer().AsSpan());
+                        return _parser.ParseFrom(data.AsSpan());
 #endif
                     }
                 }
@@ -324,7 +324,7 @@ namespace MASES.KNet.Serialization.Protobuf
                         using var stream = data.ToStream();
                         return _parser.ParseFrom(stream);
 #else
-                        return _parser.ParseFrom(data.ToDirectBuffer().AsSpan());
+                        return _parser.ParseFrom(data.AsSpan());
 #endif
                     }
                 }

--- a/src/net/KNet/KNet.csproj
+++ b/src/net/KNet/KNet.csproj
@@ -42,7 +42,7 @@
 		<None Include="..\..\documentation\articles\usage.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="MASES.JNet" Version="2.6.9-rc93">
+		<PackageReference Include="MASES.JNet" Version="2.6.9-rc94">
 			<IncludeAssets>All</IncludeAssets>
 			<PrivateAssets>None</PrivateAssets>
 		</PackageReference>

--- a/src/net/KNet/Specific/Consumer/ConsumerRecord.cs
+++ b/src/net/KNet/Specific/Consumer/ConsumerRecord.cs
@@ -184,7 +184,13 @@ namespace MASES.KNet.Consumer
                 if (!_localKeyDes)
                 {
                     _keyDeserializer ??= _factory?.BuildKeySerDes<K, TJVMK>();
-                    _localKey = _keyDeserializer.UseHeaders ? _keyDeserializer.DeserializeWithHeaders(Topic, Headers, _record.Key()) : _keyDeserializer.Deserialize(Topic, _record.Key());
+                    var key = _record.Key();
+                    try
+                    {
+                        _localKey = _keyDeserializer.UseHeaders ? _keyDeserializer.DeserializeWithHeaders(Topic, Headers, key)
+                                                                : _keyDeserializer.Deserialize(Topic, key);
+                    }
+                    finally { (key as IDisposable)?.Dispose(); }
                     _localKeyDes = true;
                 }
                 return _localKey;
@@ -202,7 +208,13 @@ namespace MASES.KNet.Consumer
                 if (!_localValueDes)
                 {
                     _valueDeserializer ??= _factory?.BuildValueSerDes<V, TJVMV>();
-                    _localValue = _valueDeserializer.UseHeaders ? _valueDeserializer.DeserializeWithHeaders(Topic, Headers, _record.Value()) : _valueDeserializer.Deserialize(Topic, _record.Value());
+                    var value = _record.Value();
+                    try
+                    {
+                        _localValue = _valueDeserializer.UseHeaders ? _valueDeserializer.DeserializeWithHeaders(Topic, Headers, value)
+                                                                    : _valueDeserializer.Deserialize(Topic, value);
+                    }
+                    finally { (value as IDisposable)?.Dispose(); }
                     _localValueDes = true;
                 }
                 return _localValue;

--- a/src/net/KNet/Specific/KNetConfigurationFromMap.cs
+++ b/src/net/KNet/Specific/KNetConfigurationFromMap.cs
@@ -113,7 +113,7 @@ namespace MASES.KNet
             _configuration1 = configuration;
         }
 
-        object GetValue(string key)
+        object GetValue(Java.Lang.String key)
         {
             if (_configuration != null && _configuration.ContainsKey(key))
             {
@@ -134,18 +134,19 @@ namespace MASES.KNet
         /// <inheritdoc/>
         public short GetShort(string key)
         {
+            using Java.Lang.String jString = key;
             if (_configuration1 != null)
             {
-                if (_configuration1.ContainsKey(key))
+                if (_configuration1.ContainsKey(jString))
                 {
-                    var value = _configuration1.Get(key);
+                    using var value = _configuration1.Get(jString);
                     return short.TryParse(value, out var converted) ? converted
                                                                     : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in short"); ;
                 }
                 throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
             }
 
-            var result = GetValue(key);
+            var result = GetValue(jString);
 
             if (result is short data)
             {
@@ -153,25 +154,26 @@ namespace MASES.KNet
             }
             else if (result is IJavaObject obj)
             {
-                return obj.Convert<short>();
+                using (obj) { return obj.Convert<short>(); }
             }
             else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in short");
         }
         /// <inheritdoc/>
         public int GetInt(string key)
         {
+            using Java.Lang.String jString = key;
             if (_configuration1 != null)
             {
-                if (_configuration1.ContainsKey(key))
+                if (_configuration1.ContainsKey(jString))
                 {
-                    var value = _configuration1.Get(key);
+                    var value = _configuration1.Get(jString);
                     return int.TryParse(value, out var converted) ? converted
                                                                   : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in int"); ;
                 }
                 throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
             }
 
-            var result = GetValue(key);
+            var result = GetValue(jString);
 
             if (result is int data)
             {
@@ -179,25 +181,26 @@ namespace MASES.KNet
             }
             else if (result is IJavaObject obj)
             {
-                return obj.Convert<int>();
+                using (obj) { return obj.Convert<int>(); }
             }
             else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in int");
         }
         /// <inheritdoc/>
         public long GetLong(string key)
         {
+            using Java.Lang.String jString = key;
             if (_configuration1 != null)
             {
-                if (_configuration1.ContainsKey(key))
+                if (_configuration1.ContainsKey(jString))
                 {
-                    var value = _configuration1.Get(key);
+                    var value = _configuration1.Get(jString);
                     return long.TryParse(value, out var converted) ? converted
                                                                    : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in long"); ;
                 }
                 throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
             }
 
-            var result = GetValue(key);
+            var result = GetValue(jString);
 
             if (result is long data)
             {
@@ -205,25 +208,26 @@ namespace MASES.KNet
             }
             else if (result is IJavaObject obj)
             {
-                return obj.Convert<long>();
+                using (obj) { return obj.Convert<long>(); }
             }
             else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in long");
         }
         /// <inheritdoc/>
         public double GetDouble(string key)
         {
+            using Java.Lang.String jString = key;
             if (_configuration1 != null)
             {
-                if (_configuration1.ContainsKey(key))
+                if (_configuration1.ContainsKey(jString))
                 {
-                    var value = _configuration1.Get(key);
+                    var value = _configuration1.Get(jString);
                     return double.TryParse(value, out var converted) ? converted
                                                                      : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in double"); ;
                 }
                 throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
             }
 
-            var result = GetValue(key);
+            var result = GetValue(jString);
 
             if (result is double data)
             {
@@ -231,7 +235,7 @@ namespace MASES.KNet
             }
             else if (result is IJavaObject obj)
             {
-                return obj.Convert<double>();
+                using (obj) { return obj.Convert<double>(); }
             }
             else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in double");
         }
@@ -242,8 +246,8 @@ namespace MASES.KNet
             {
                 throw new InvalidOperationException($"Cannot manage configuration key \"{key}\" as List.");
             }
-
-            var result = GetValue(key);
+            using Java.Lang.String jString = key;
+            var result = GetValue(jString);
 
             if (result is IJavaObject obj)
             {
@@ -260,18 +264,19 @@ namespace MASES.KNet
         /// <inheritdoc/>
         public bool GetBoolean(string key)
         {
+            using Java.Lang.String jString = key;
             if (_configuration1 != null)
             {
-                if (_configuration1.ContainsKey(key))
+                if (_configuration1.ContainsKey(jString))
                 {
-                    var value = _configuration1.Get(key);
+                    var value = _configuration1.Get(jString);
                     return bool.TryParse(value, out var converted) ? converted
                                                                    : throw new InvalidCastException($"Key \"{key}\" returns a value {value} cannot be converted in bool"); ;
                 }
                 throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
             }
 
-            var result = GetValue(key);
+            var result = GetValue(jString);
 
             if (result is bool data)
             {
@@ -279,23 +284,24 @@ namespace MASES.KNet
             }
             else if (result is IJavaObject obj)
             {
-                return obj.Convert<bool>();
+                using (obj) { return obj.Convert<bool>(); }
             }
             else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in bool");
         }
         /// <inheritdoc/>
         public string GetString(string key)
         {
+            using Java.Lang.String jString = key;
             if (_configuration1 != null)
             {
-                if (_configuration1.ContainsKey(key))
+                if (_configuration1.ContainsKey(jString))
                 {
-                    return _configuration1.Get(key);
+                    return _configuration1.Get(jString);
                 }
                 throw new InvalidOperationException($"Configuration key \"{key}\" is not available.");
             }
 
-            var result = GetValue(key);
+            var result = GetValue(jString);
 
             if (result is string data)
             {
@@ -303,7 +309,7 @@ namespace MASES.KNet
             }
             else if (result is IJavaObject obj)
             {
-                return obj.Convert<string>();
+                using (obj) { return obj.Convert<string>(); }
             }
             else throw new InvalidCastException($"Key \"{key}\" returns a value {(result ?? "null")} cannot be converted in string");
         }
@@ -314,8 +320,8 @@ namespace MASES.KNet
             {
                 throw new InvalidOperationException($"Cannot manage configuration key \"{key}\" as Password.");
             }
-
-            var result = GetValue(key);
+            using Java.Lang.String jString = key;
+            var result = GetValue(jString);
 
             if (result is Password data)
             {
@@ -334,8 +340,8 @@ namespace MASES.KNet
             {
                 throw new InvalidOperationException($"Cannot manage configuration key \"{key}\" as Class.");
             }
-
-            var result = GetValue(key);
+            using Java.Lang.String jString = key;
+            var result = GetValue(jString);
 
             if (result is Java.Lang.Class data)
             {
@@ -352,16 +358,26 @@ namespace MASES.KNet
         {
             if (_configuration != null)
             {
-                foreach (var item in _configuration.EntrySet())
+                using var entrySet = _configuration.EntrySet();
+                foreach (var item in entrySet)
                 {
-                    yield return new KeyValuePair<string, object>(item.Key, item.Value);
+                    using (item)
+                    {
+                        using var key = item.Key;
+                        yield return new KeyValuePair<string, object>(key, item.Value);
+                    }
                 }
             }
             else if (_configuration1 != null)
             {
-                foreach (var item in _configuration1.EntrySet())
+                using var entrySet = _configuration1.EntrySet();
+                foreach (var item in entrySet)
                 {
-                    yield return new KeyValuePair<string, object>(item.Key, item.Value);
+                    using (item)
+                    {
+                        using var key = item.Key;
+                        yield return new KeyValuePair<string, object>(key, item.Value);
+                    }
                 }
             }
             else throw new InvalidOperationException("Unable to execute enumeration.");

--- a/src/net/KNet/Specific/Producer/KNetProducer.cs
+++ b/src/net/KNet/Specific/Producer/KNetProducer.cs
@@ -286,18 +286,22 @@ namespace MASES.KNet.Producer
                 localHeaders = true;
                 headers = Headers.Create();
             }
+            using Java.Lang.String topic = record.Topic;
+            using Java.Lang.Integer partition = record.Partition;
+            using Java.Lang.Long timestamp = record.Timestamp;
+            TJVMK jVMK = record.Key == null ? default : DataSerialize(keySerializer, record.Topic, record.Key, headers);
+            TJVMV jVMV = record.Value == null ? default : DataSerialize(valueSerializer, record.Topic, record.Value, headers);
+            IDisposable disposableKey = jVMK as IDisposable;
+            IDisposable disposableValue = jVMV as IDisposable;
             try
             {
-                return new Org.Apache.Kafka.Clients.Producer.ProducerRecord<TJVMK, TJVMV>(record.Topic, record.Partition, record.Timestamp,
-                                                                                          record.Key == null ? null
-                                                                                                             : DataSerialize(keySerializer, record.Topic, record.Key, headers),
-                                                                                          record.Value == null ? null
-                                                                                                               : DataSerialize(valueSerializer, record.Topic, record.Value, headers),
-                                                                                          headers);
+                return new Org.Apache.Kafka.Clients.Producer.ProducerRecord<TJVMK, TJVMV>(topic, partition, timestamp, jVMK, jVMV, headers);
             }
             finally
             {
                 if (localHeaders) headers?.Dispose();
+                disposableKey?.Dispose();
+                disposableValue?.Dispose();
             }
         }
 
@@ -327,32 +331,90 @@ namespace MASES.KNet.Producer
         /// <inheritdoc cref="IProducer{K, V, TJVMK, TJVMV}.Send(string, int?, long?, K, V, Headers)"/>
         public Future<RecordMetadata> Send(string topic, int? partition, long? timestamp, K key, V value, Headers headers)
         {
-            return IExecute<Future<RecordMetadata>>("send", topic, partition, timestamp, _keySerializer.SerializeWithHeaders(topic, headers, key), _valueSerializer.SerializeWithHeaders(topic, headers, value), headers);
+            var jKey = _keySerializer.SerializeWithHeaders(topic, headers, key);
+            var jValue = _valueSerializer.SerializeWithHeaders(topic, headers, value);
+            try
+            {
+                return IExecute<Future<RecordMetadata>>("send", topic, partition, timestamp, jKey, jValue, headers);
+            }
+            finally
+            {
+                (jKey as IDisposable).Dispose();    
+                (jValue as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="IProducer{K, V, TJVMK, TJVMV}.Send(string, int?, long?, K, V)"/>
         public Future<RecordMetadata> Send(string topic, int? partition, long? timestamp, K key, V value)
         {
-            return IExecute<Future<RecordMetadata>>("send", topic, partition, timestamp, _keySerializer.Serialize(topic, key), _valueSerializer.Serialize(topic, value));
+            var jKey = _keySerializer.Serialize(topic, key);
+            var jValue = _valueSerializer.Serialize(topic, value);
+            try
+            {
+                return IExecute<Future<RecordMetadata>>("send", topic, partition, timestamp, jKey, jValue);
+            }
+            finally
+            {
+                (jKey as IDisposable).Dispose();
+                (jValue as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="IProducer{K, V, TJVMK, TJVMV}.Send(string, int?, K, V, Headers)"/>
         public Future<RecordMetadata> Send(string topic, int? partition, K key, V value, Headers headers)
         {
-            return IExecute<Future<RecordMetadata>>("send", topic, partition, _keySerializer.SerializeWithHeaders(topic, headers, key), _valueSerializer.SerializeWithHeaders(topic, headers, value), headers);
+            var jKey = _keySerializer.SerializeWithHeaders(topic, headers, key);
+            var jValue = _valueSerializer.SerializeWithHeaders(topic, headers, value);
+            try
+            {
+                return IExecute<Future<RecordMetadata>>("send", topic, partition, jKey, jValue, headers);
+            }
+            finally
+            {
+                (jKey as IDisposable).Dispose();
+                (jValue as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="IProducer{K, V, TJVMK, TJVMV}.Send(string, int?, K, V, Headers)"/>
         public Future<RecordMetadata> Send(string topic, int? partition, K key, V value)
         {
-            return IExecute<Future<RecordMetadata>>("send", topic, partition, _keySerializer.Serialize(topic, key), _valueSerializer.Serialize(topic, value));
+            var jKey = _keySerializer.Serialize(topic, key);
+            var jValue = _valueSerializer.Serialize(topic, value);
+            try
+            {
+                return IExecute<Future<RecordMetadata>>("send", topic, partition, jKey, jValue);
+            }
+            finally
+            {
+                (jKey as IDisposable).Dispose();
+                (jValue as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="IProducer{K, V, TJVMK, TJVMV}.Send(string, K, V)"/>
         public Future<RecordMetadata> Send(string topic, K key, V value)
         {
-            return IExecute<Future<RecordMetadata>>("send", topic, _keySerializer.Serialize(topic, key), _valueSerializer.Serialize(topic, value));
+            var jKey = _keySerializer.Serialize(topic, key);
+            var jValue = _valueSerializer.Serialize(topic, value);
+            try
+            {
+                return IExecute<Future<RecordMetadata>>("send", topic, jKey, jValue);
+            }
+            finally
+            {
+                (jKey as IDisposable).Dispose();
+                (jValue as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="IProducer{K, V, TJVMK, TJVMV}.Send(string, V)"/>
         public Future<RecordMetadata> Send(string topic, V value)
         {
-            return IExecute<Future<RecordMetadata>>("send", topic, _valueSerializer.Serialize(topic, value));
+            var jValue = _valueSerializer.Serialize(topic, value);
+            try
+            {
+                return IExecute<Future<RecordMetadata>>("send", topic, jValue);
+            }
+            finally
+            {
+                (jValue as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="IProducer{K, V, TJVMK, TJVMV}.Produce(string, K, V, Action{RecordMetadata, JVMBridgeException})"/>
         public void Produce(string topic, K key, V value, Action<RecordMetadata, JVMBridgeException> action = null)

--- a/src/net/KNet/Specific/Serialization/KNetSerialization.cs
+++ b/src/net/KNet/Specific/Serialization/KNetSerialization.cs
@@ -59,6 +59,7 @@ namespace MASES.KNet.Serialization
             }
             return main;
         }
+
         static readonly bool ShallRevertByteOrderShort = CheckRevert(BitConverter.GetBytes((short)1), _ShortSerializer.Serialize("", Java.Lang.Short.ValueOf(1)));
         static readonly bool ShallRevertByteOrderInt = CheckRevert(BitConverter.GetBytes(1), _IntSerializer.Serialize("", Java.Lang.Integer.ValueOf(1)));
         static readonly bool ShallRevertByteOrderLong = CheckRevert(BitConverter.GetBytes((long)1), _LongSerializer.Serialize("", Java.Lang.Long.ValueOf(1)));
@@ -322,7 +323,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeBoolean(bool fallbackToKafka, string topic, bool data)
         {
-            if (fallbackToKafka) return _BooleanSerializer.Serialize(topic, data);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Boolean jValue = data;
+                return _BooleanSerializer.Serialize(jTopic, jValue);
+            }
             return BitConverter.GetBytes(data);
         }
 
@@ -331,7 +337,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeBoolean(bool fallbackToKafka, string topic, bool? data)
         {
-            if (fallbackToKafka) return _BooleanSerializer.Serialize(topic, data.HasValue ? data.Value : null);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Boolean jValue = data;
+                return _BooleanSerializer.Serialize(jTopic, jValue); 
+            }
             return data.HasValue ? BitConverter.GetBytes(data.Value) : null;
         }
 
@@ -348,7 +359,11 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeByteBuffer(bool fallbackToKafka, string topic, Java.Nio.ByteBuffer data)
         {
-            if (fallbackToKafka) return _ByteBufferSerializer.Serialize(topic, data);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                return _ByteBufferSerializer.Serialize(jTopic, data);
+            }
             return data.ToArray(true);
         }
 
@@ -357,7 +372,8 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeBytes(bool fallbackToKafka, string topic, Org.Apache.Kafka.Common.Utils.Bytes data)
         {
-            return _BytesSerializer.Serialize(topic, data);
+            using Java.Lang.String jTopic = topic;
+            return _BytesSerializer.Serialize(jTopic, data);
         }
 
         /// <summary>
@@ -365,7 +381,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeDouble(bool fallbackToKafka, string topic, double data)
         {
-            if (fallbackToKafka) return _DoubleSerializer.Serialize(topic, data);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Double jValue = data;
+                return _DoubleSerializer.Serialize(jTopic, jValue);
+            }
             var array = BitConverter.GetBytes(data);
             if (ShallRevertByteOrderDouble) Array.Reverse(array);
             return array;
@@ -376,7 +397,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeDouble(bool fallbackToKafka, string topic, double? data)
         {
-            if (fallbackToKafka) return _DoubleSerializer.Serialize(topic, data.HasValue ? data.Value : null);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Double jValue = data;
+                return _DoubleSerializer.Serialize(jTopic, jValue);
+            }
             if (!data.HasValue) return null;
             var array = BitConverter.GetBytes(data.Value);
             if (ShallRevertByteOrderDouble) Array.Reverse(array);
@@ -388,7 +414,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeFloat(bool fallbackToKafka, string topic, float data)
         {
-            if (fallbackToKafka) return _FloatSerializer.Serialize(topic, data);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Float jValue = data;
+                return _FloatSerializer.Serialize(jTopic, jValue);
+            }
             var array = BitConverter.GetBytes(data);
             if (ShallRevertByteOrderFloat) Array.Reverse(array);
             return array;
@@ -399,7 +430,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeFloat(bool fallbackToKafka, string topic, float? data)
         {
-            if (fallbackToKafka) return _FloatSerializer.Serialize(topic, data.HasValue ? data.Value : null);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Float jValue = data;
+                return _FloatSerializer.Serialize(jTopic, jValue);
+            }
             if (!data.HasValue) return null;
             var array = BitConverter.GetBytes(data.Value);
             if (ShallRevertByteOrderFloat) Array.Reverse(array);
@@ -411,7 +447,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeInt(bool fallbackToKafka, string topic, int data)
         {
-            if (fallbackToKafka) return _IntSerializer.Serialize(topic, data);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Integer jValue = data;
+                return _IntSerializer.Serialize(jTopic, jValue);
+            }
             var array = BitConverter.GetBytes(data);
             if (ShallRevertByteOrderInt) Array.Reverse(array);
             return array;
@@ -425,7 +466,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeInt(bool fallbackToKafka, string topic, int? data)
         {
-            if (fallbackToKafka) return _IntSerializer.Serialize(topic, data.HasValue ? data.Value : null);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Integer jValue = data;
+                return _IntSerializer.Serialize(jTopic, jValue);
+            }
             if (!data.HasValue) return null;
             var array = BitConverter.GetBytes(data.Value);
             if (ShallRevertByteOrderInt) Array.Reverse(array);
@@ -440,7 +486,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeLong(bool fallbackToKafka, string topic, long data)
         {
-            if (fallbackToKafka) return _LongSerializer.Serialize(topic, data);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Long jValue = data;
+                return _LongSerializer.Serialize(jTopic, jValue);
+            }
             var array = BitConverter.GetBytes(data);
             if (ShallRevertByteOrderLong) Array.Reverse(array);
             return array;
@@ -454,7 +505,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeLong(bool fallbackToKafka, string topic, long? data)
         {
-            if (fallbackToKafka) return _LongSerializer.Serialize(topic, data.HasValue ? data.Value : null);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Long jValue = data;
+                return _LongSerializer.Serialize(jTopic, jValue);
+            }
             if (!data.HasValue) return null;
             var array = BitConverter.GetBytes(data.Value);
             if (ShallRevertByteOrderLong) Array.Reverse(array);
@@ -469,7 +525,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeShort(bool fallbackToKafka, string topic, short data)
         {
-            if (fallbackToKafka) return _ShortSerializer.Serialize(topic, data);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Short jValue = data;
+                return _ShortSerializer.Serialize(jTopic, jValue);
+            }
             var array = BitConverter.GetBytes(data);
             if (ShallRevertByteOrderShort) Array.Reverse(array);
             return array;
@@ -483,7 +544,12 @@ namespace MASES.KNet.Serialization
         /// </summary>
         public static byte[] SerializeShort(bool fallbackToKafka, string topic, short? data)
         {
-            if (fallbackToKafka) return _ShortSerializer.Serialize(topic, data.HasValue ? data.Value : null);
+            if (fallbackToKafka)
+            {
+                using Java.Lang.String jTopic = topic;
+                using Java.Lang.Short jValue = data;
+                return _ShortSerializer.Serialize(jTopic, jValue);
+            }
             if (!data.HasValue) return null;
             var array = BitConverter.GetBytes(data.Value);
             if (ShallRevertByteOrderShort) Array.Reverse(array);
@@ -566,7 +632,8 @@ namespace MASES.KNet.Serialization
         public static Java.Nio.ByteBuffer DeserializeByteBuffer(bool fallbackToKafka, string topic, byte[] data)
         {
             if (data == null || data.Length == 0) return default;
-            return JVMBridgeBase.WrapsDirect<Java.Nio.ByteBuffer>(_ByteBufferDeserializer.Deserialize(topic, data) as IJavaObject);
+            using Java.Lang.String jTopic = topic;
+            return JVMBridgeBase.WrapsDirect<Java.Nio.ByteBuffer>(_ByteBufferDeserializer.Deserialize(jTopic, data) as IJavaObject);
         }
 
         /// <summary>
@@ -575,7 +642,8 @@ namespace MASES.KNet.Serialization
         public static Org.Apache.Kafka.Common.Utils.Bytes DeserializeBytes(bool fallbackToKafka, string topic, byte[] data)
         {
             if (data == null || data.Length == 0) return default;
-            return JVMBridgeBase.WrapsDirect<Org.Apache.Kafka.Common.Utils.Bytes>(_BytesDeserializer.Deserialize(topic, data) as IJavaObject);
+            using Java.Lang.String jTopic = topic;
+            return JVMBridgeBase.WrapsDirect<Org.Apache.Kafka.Common.Utils.Bytes>(_BytesDeserializer.Deserialize(jTopic, data) as IJavaObject);
         }
 
         /// <summary>
@@ -586,7 +654,8 @@ namespace MASES.KNet.Serialization
             if (data == null || data.Length == 0) return default;
             if (fallbackToKafka)
             {
-                var result = _DoubleDeserializer.Deserialize(topic, data);
+                using Java.Lang.String jTopic = topic;
+                var result = _DoubleDeserializer.Deserialize(jTopic, data);
                 if (result is IJavaObject ijo)
                 {
                     return JVMBridgeBase.WrapsDirect<Java.Lang.Double>(ijo);
@@ -614,7 +683,8 @@ namespace MASES.KNet.Serialization
             if (data == null || data.Length == 0) return default;
             if (fallbackToKafka)
             {
-                var result = _FloatDeserializer.Deserialize(topic, data);
+                using Java.Lang.String jTopic = topic;
+                var result = _FloatDeserializer.Deserialize(jTopic, data);
                 if (result is IJavaObject ijo)
                 {
                     return JVMBridgeBase.WrapsDirect<Java.Lang.Float>(ijo);
@@ -642,7 +712,8 @@ namespace MASES.KNet.Serialization
             if (data == null || data.Length == 0) return default;
             if (fallbackToKafka)
             {
-                var result = _IntDeserializer.Deserialize(topic, data);
+                using Java.Lang.String jTopic = topic;
+                var result = _IntDeserializer.Deserialize(jTopic, data);
                 if (result is IJavaObject ijo)
                 {
                     return JVMBridgeBase.WrapsDirect<Java.Lang.Integer>(ijo);
@@ -695,7 +766,8 @@ namespace MASES.KNet.Serialization
             if (data == null || data.Length == 0) return default;
             if (fallbackToKafka)
             {
-                var result = _LongDeserializer.Deserialize(topic, data);
+                using Java.Lang.String jTopic = topic;
+                var result = _LongDeserializer.Deserialize(jTopic, data);
                 if (result is IJavaObject ijo)
                 {
                     return JVMBridgeBase.WrapsDirect<Java.Lang.Long>(ijo);
@@ -748,7 +820,8 @@ namespace MASES.KNet.Serialization
             if (data == null || data.Length == 0) return default;
             if (fallbackToKafka)
             {
-                var result = _ShortDeserializer.Deserialize(topic, data);
+                using Java.Lang.String jTopic = topic;
+                var result = _ShortDeserializer.Deserialize(jTopic, data);
                 if (result is IJavaObject ijo)
                 {
                     return JVMBridgeBase.WrapsDirect<Java.Lang.Short>(ijo);

--- a/src/net/KNet/Specific/Streams/KNetStreams.cs
+++ b/src/net/KNet/Specific/Streams/KNetStreams.cs
@@ -16,6 +16,7 @@
 *  Refer to LICENSE for more information.
 */
 
+using Java.Time;
 using MASES.KNet.Serialization;
 using MASES.KNet.Streams.Processor;
 using MASES.KNet.Streams.State;
@@ -150,24 +151,38 @@ namespace MASES.KNet.Streams
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.QueryMetadataForKey{K}(Java.Lang.String, K, Org.Apache.Kafka.Common.Serialization.Serializer{K})"/>
         public Org.Apache.Kafka.Streams.KeyQueryMetadata QueryMetadataForKey<K, TJVMK>(string arg0, K arg1, ISerializer<K, TJVMK> arg2)
         {
-            return _inner.QueryMetadataForKey<TJVMK>(arg0, arg2.Serialize(null, arg1), arg2.KafkaSerializer);
+            using Java.Lang.String jArg0 = arg0;
+            var tJVMK = arg2.Serialize(null, arg1);
+            try
+            {
+                return _inner.QueryMetadataForKey<TJVMK>(jArg0, tJVMK, arg2.KafkaSerializer);
+            }
+            finally { (tJVMK as IDisposable)?.Dispose(); }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.QueryMetadataForKey{K}(Java.Lang.String, K, Org.Apache.Kafka.Common.Serialization.Serializer{K})"/>
         public Org.Apache.Kafka.Streams.KeyQueryMetadata QueryMetadataForKey<K>(string arg0, K arg1, ISerializer<K, byte[]> arg2)
         {
-            return QueryMetadataForKey<K, byte[]>(arg0, arg1, arg2);
+            using Java.Lang.String jArg0 = arg0;
+            return QueryMetadataForKey<K, byte[]>(jArg0, arg1, arg2);
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.QueryMetadataForKey{K, Arg2objectSuperK}(Java.Lang.String, K, Org.Apache.Kafka.Streams.Processor.StreamPartitioner{Arg2objectSuperK, object})"/>
         public Org.Apache.Kafka.Streams.KeyQueryMetadata QueryMetadataForKey<K, TJVMK>(string arg0, K arg1, StreamPartitioner<K, object> arg2)
         {
             if (arg2 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
             var keySerDes = _factory?.BuildKeySerDes<K, TJVMK>();
-            return _inner.IExecute<Org.Apache.Kafka.Streams.KeyQueryMetadata>("queryMetadataForKey", arg0, keySerDes.Serialize(null, arg1), arg2);
+            using Java.Lang.String jArg0 = arg0;
+            var tJVMK = keySerDes.Serialize(null, arg1);
+            try
+            {
+                return _inner.IExecute<Org.Apache.Kafka.Streams.KeyQueryMetadata>("queryMetadataForKey", jArg0, tJVMK, arg2);
+            }
+            finally { (tJVMK as IDisposable)?.Dispose(); }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.QueryMetadataForKey{K}(Java.Lang.String, K, Org.Apache.Kafka.Common.Serialization.Serializer{K})"/>
         public Org.Apache.Kafka.Streams.KeyQueryMetadata QueryMetadataForKey<K>(string arg0, K arg1, StreamPartitioner<K, object> arg2)
         {
-            return QueryMetadataForKey<K, byte[]>(arg0, arg1, arg2);
+            using Java.Lang.String jArg0 = arg0;
+            return QueryMetadataForKey<K, byte[]>(jArg0, arg1, arg2);
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.Query{R}(Org.Apache.Kafka.Streams.Query.StateQueryRequest{R})"/>
         public Org.Apache.Kafka.Streams.Query.StateQueryResult<R> Query<R>(Org.Apache.Kafka.Streams.Query.StateQueryRequest<R> arg0)
@@ -191,7 +206,8 @@ namespace MASES.KNet.Streams
         public TKNetManagedStore Store<TKNetManagedStore, TStore>(string storageId, QueryableStoreTypes.StoreType<TKNetManagedStore, TStore> storeType)
             where TKNetManagedStore : ManagedStore<TStore>, IGenericSerDesFactoryApplier, new()
         {
-            var sqp = Org.Apache.Kafka.Streams.StoreQueryParameters<TStore>.FromNameAndType(storageId, storeType.Store);
+            using Java.Lang.String jStorageId = storageId;
+            var sqp = Org.Apache.Kafka.Streams.StoreQueryParameters<TStore>.FromNameAndType(jStorageId, storeType.Store);
             TKNetManagedStore store = new();
             var substore = _inner.Store<TStore>(sqp);
             if (store is IManagedStore<TStore> knetManagedStore)
@@ -207,7 +223,8 @@ namespace MASES.KNet.Streams
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.StreamsMetadataForStore(Java.Lang.String)"/>
         public Java.Util.Collection<Org.Apache.Kafka.Streams.StreamsMetadata> StreamsMetadataForStore(string arg0)
         {
-            return _inner.StreamsMetadataForStore(arg0);
+            using Java.Lang.String jStorageId = arg0;
+            return _inner.StreamsMetadataForStore(jStorageId);
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.AllLocalStorePartitionLags"/>
         public Java.Util.Map<Java.Lang.String, Java.Util.Map<Java.Lang.Integer, Org.Apache.Kafka.Streams.LagInfo>> AllLocalStorePartitionLags => _inner.AllLocalStorePartitionLags();
@@ -229,7 +246,8 @@ namespace MASES.KNet.Streams
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.RemoveStreamThread(Java.Time.Duration)"/>
         public Java.Lang.String RemoveStreamThread(TimeSpan arg0)
         {
-            var res = _inner.RemoveStreamThread(arg0);
+            using Duration jArg0 = arg0;
+            using var res = _inner.RemoveStreamThread(jArg0);
             return res.IsPresent() ? res.Get() : null;
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.MetadataForLocalThreads"/>
@@ -239,6 +257,7 @@ namespace MASES.KNet.Streams
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.Close()"/>
         public bool Close(TimeSpan arg0)
         {
+            using Duration jArg0 = arg0;
             return _inner.Close(arg0);
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.KafkaStreams.Close(Java.Time.Duration)"/>

--- a/src/net/KNet/Specific/Streams/KeyValue.cs
+++ b/src/net/KNet/Specific/Streams/KeyValue.cs
@@ -55,12 +55,22 @@ namespace MASES.KNet.Streams
             {
                 _keySerDes ??= _factory?.BuildKeySerDes<K, TJVMK>();
                 if (_keySerDes == null) throw new InvalidOperationException("Unable to resolve key serializer/deserializer for prefetched KeyValue.");
-                _key = _keySerDes.Deserialize(null, _inner.Key);
-                _keyStored = true;
+                var jKey = _inner.Key;
+                try
+                {
+                    _key = _keySerDes.Deserialize(null, jKey);
+                    _keyStored = true;
+                }
+                finally { (jKey as IDisposable)?.Dispose(); }
                 _valueSerDes ??= _factory?.BuildValueSerDes<V, TJVMV>();
                 if (_valueSerDes == null) throw new InvalidOperationException("Unable to resolve value serializer/deserializer for prefetched KeyValue.");
-                _value = _valueSerDes.Deserialize(null, _inner.Value);
-                _valueStored = true;
+                var jValue = _inner.Value;
+                try
+                {
+                    _value = _valueSerDes.Deserialize(null, jValue);
+                    _valueStored = true;
+                }
+                finally { (jValue as IDisposable)?.Dispose(); }
             }
         }
 
@@ -105,8 +115,13 @@ namespace MASES.KNet.Streams
                 if (!_keyStored)
                 {
                     _keySerDes ??= _factory?.BuildKeySerDes<K, TJVMK>() ?? throw new InvalidOperationException("Key serializer/deserializer is not available.");
-                    _key = _keySerDes.Deserialize(null, _inner.Key);
-                    _keyStored = true;
+                    var key = _inner.Key;
+                    try
+                    {
+                        _key = _keySerDes.Deserialize(null, key);
+                        _keyStored = true;
+                    }
+                    finally { (key as IDisposable)?.Dispose(); }
                 }
                 return _key;
             }
@@ -122,8 +137,13 @@ namespace MASES.KNet.Streams
                 if (!_valueStored)
                 {
                     _valueSerDes ??= _factory?.BuildValueSerDes<V, TJVMV>() ?? throw new InvalidOperationException("Value serializer/deserializer is not available.");
-                    _value = _valueSerDes.Deserialize(null, _inner.Value);
-                    _valueStored = true;
+                    var value = _inner.Value;
+                    try
+                    {
+                        _value = _valueSerDes.Deserialize(null, value);
+                        _valueStored = true;
+                    }
+                    finally { (value as IDisposable)?.Dispose(); }
                 }
                 return _value;
             }

--- a/src/net/KNet/Specific/Streams/Kstream/Aggregator.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Aggregator.cs
@@ -96,14 +96,23 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public sealed override TJVMVA Apply(TJVMK arg0, TJVMV arg1, TJVMVA arg2)
         {
-            _keySet = _valueSet = _aggregateSet = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
-            _arg2 = arg2;
+            try
+            {
+                _keySet = _valueSet = _aggregateSet = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
+                _arg2 = arg2;
 
-            VA res = (OnApply != null) ? OnApply(this) : Apply();
-            _vaSerializer ??= Factory?.BuildValueSerDes<VA, TJVMVA>();
-            return _vaSerializer.Serialize(null, res);
+                VA res = (OnApply != null) ? OnApply(this) : Apply();
+                _vaSerializer ??= Factory?.BuildValueSerDes<VA, TJVMVA>();
+                return _vaSerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+                (arg2 as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.Aggregator{K, V, VAgg}.Apply(K, V, VAgg)"/>
         public virtual VA Apply()

--- a/src/net/KNet/Specific/Streams/Kstream/Aggregator.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Aggregator.cs
@@ -45,6 +45,20 @@ namespace MASES.KNet.Streams.Kstream
         ISerDes<V, TJVMV> _vSerializer = null;
         ISerDes<VA, TJVMVA> _vaSerializer = null;
 
+        /// <inheritdoc/>
+        public Aggregator()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(TJVMK, TJVMV, TJVMVA)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMVA result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/Branched.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Branched.cs
@@ -89,7 +89,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Branched{K, V, TJVMK, TJVMV}"/></returns>
         public static Branched<K, V, TJVMK, TJVMV> As(string arg0)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Branched<TJVMK, TJVMV>.As(arg0);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Branched<TJVMK, TJVMV>.As(jString);
             return new Branched<K, V, TJVMK, TJVMV>(cons);
         }
         /// <summary>
@@ -100,7 +101,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Branched{K, V, TJVMK, TJVMV}"/></returns>
         public static Branched<K, V, TJVMK, TJVMV> WithConsumer(KStreamConsumer<K, V, TJVMK, TJVMV> arg0, string arg1)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Branched<TJVMK, TJVMV>.WithConsumer(arg0, arg1);
+            using Java.Lang.String jString = arg1;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Branched<TJVMK, TJVMV>.WithConsumer(arg0, jString);
             return new Branched<K, V, TJVMK, TJVMV>(cons);
         }
         /// <summary>
@@ -121,7 +123,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Branched{K, V, TJVMK, TJVMV}"/></returns>
         public static Branched<K, V, TJVMK, TJVMV> WithFunction(KStreamFunction<K, V, TJVMK, TJVMV> arg0, string arg1)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Branched<TJVMK, TJVMV>.WithFunction(arg0, arg1);
+            using Java.Lang.String jString = arg1;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Branched<TJVMK, TJVMV>.WithFunction(arg0, jString);
             return new Branched<K, V, TJVMK, TJVMV>(cons);
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/Consumed.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Consumed.cs
@@ -101,7 +101,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Consumed{K, V, TJVMK, TJVMV}"/></returns>
         public static Consumed<K, V, TJVMK, TJVMV> As(string arg0)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Consumed<TJVMK, TJVMV>.As(arg0);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Consumed<TJVMK, TJVMV>.As(jString);
             return new Consumed<K, V, TJVMK, TJVMV>(cons);
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/ForeachAction.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ForeachAction.cs
@@ -72,13 +72,21 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public sealed override void Apply(TJVMK arg0, TJVMV arg1)
         {
-            _kSerializer ??= Factory?.BuildKeySerDes<K, TJVMK>();
-            _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
-            _keySet = _valueSet = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
+            try
+            {
+                _kSerializer ??= Factory?.BuildKeySerDes<K, TJVMK>();
+                _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
+                _keySet = _valueSet = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
 
-            if (OnApply != null) OnApply(this); else Apply();
+                if (OnApply != null) OnApply(this); else Apply();
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.ForeachAction{K, V}.Apply(K, V)"/>
         public virtual void Apply()

--- a/src/net/KNet/Specific/Streams/Kstream/Grouped.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Grouped.cs
@@ -88,7 +88,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Grouped{K, V, TJVMK, TJVMV}"/></returns>
         public static Grouped<K, V, TJVMK, TJVMV> As(string arg0)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Grouped<TJVMK, TJVMV>.As(arg0);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Grouped<TJVMK, TJVMV>.As(jString);
             return new Grouped<K, V, TJVMK, TJVMV>(cons);
         }
         /// <summary>
@@ -120,7 +121,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Grouped{K, V, TJVMK, TJVMV}"/></returns>
         public static Grouped<K, V, TJVMK, TJVMV> With(string arg0, ISerDes<K, TJVMK> arg1, ISerDes<V, TJVMV> arg2)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Grouped<TJVMK, TJVMV>.With(arg0, arg1.KafkaSerde, arg2.KafkaSerde);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Grouped<TJVMK, TJVMV>.With(jString, arg1.KafkaSerde, arg2.KafkaSerde);
             return new Grouped<K, V, TJVMK, TJVMV>(cons);
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/Initializer.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Initializer.cs
@@ -30,6 +30,20 @@ namespace MASES.KNet.Streams.Kstream
     {
         ISerDes<VA, TJVMVA> _valueSerializer = null;
 
+        /// <inheritdoc/>
+        public Initializer()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply()"/> or <see cref="OnApply2"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMVA result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/Joined.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Joined.cs
@@ -89,7 +89,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Joined{K, V, VO, TJVMK, TJVMV, TJVMVO}"/></returns>
         public static Joined<K, V, VO, TJVMK, TJVMV, TJVMVO> As(string arg0)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Joined<TJVMK, TJVMV, TJVMVO>.As(arg0);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Joined<TJVMK, TJVMV, TJVMVO>.As(jString);
             return new Joined<K, V, VO, TJVMK, TJVMV, TJVMVO>(cons);
         }
         /// <summary>
@@ -133,7 +134,9 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Joined{K, V, VO, TJVMK, TJVMV, TJVMVO}"/></returns>
         public static Joined<K, V, VO, TJVMK, TJVMV, TJVMVO> With(ISerDes<K, TJVMK> arg0, ISerDes<V, TJVMV> arg1, ISerDes<VO, TJVMVO> arg2, string arg3, System.TimeSpan arg4)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Joined<TJVMK, TJVMV, TJVMVO>.With(arg0.KafkaSerde, arg1.KafkaSerde, arg2.KafkaSerde, arg3, arg4);
+            using Java.Lang.String jString = arg3;
+            using Java.Time.Duration duration = arg4;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Joined<TJVMK, TJVMV, TJVMVO>.With(arg0.KafkaSerde, arg1.KafkaSerde, arg2.KafkaSerde, jString, duration);
             return new Joined<K, V, VO, TJVMK, TJVMV, TJVMVO>(cons);
         }
         /// <summary>
@@ -146,7 +149,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Joined{K, V, VO, TJVMK, TJVMV, TJVMVO}"/></returns>
         public static Joined<K, V, VO, TJVMK, TJVMV, TJVMVO> With(ISerDes<K, TJVMK> arg0, ISerDes<V, TJVMV> arg1, ISerDes<VO, TJVMVO> arg2, string arg3)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Joined<TJVMK, TJVMV, TJVMVO>.With(arg0.KafkaSerde, arg1.KafkaSerde, arg2.KafkaSerde, arg3);
+            using Java.Lang.String jString = arg3;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Joined<TJVMK, TJVMV, TJVMVO>.With(arg0.KafkaSerde, arg1.KafkaSerde, arg2.KafkaSerde, jString);
             return new Joined<K, V, VO, TJVMK, TJVMV, TJVMVO>(cons);
         }
         /// <summary>
@@ -173,7 +177,8 @@ namespace MASES.KNet.Streams.Kstream
         public Joined<K, V, VO, TJVMK, TJVMV, TJVMVO> WithGracePeriod(System.TimeSpan arg0)
         {
             CheckDisposed();
-            _inner?.WithGracePeriod(arg0);
+            using Java.Time.Duration duration = arg0;
+            _inner?.WithGracePeriod(duration);
             return this;
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/KBranchedKStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KBranchedKStream.cs
@@ -89,11 +89,15 @@ namespace MASES.KNet.Streams.Kstream
         {
             CheckDisposed();
             var dict = new System.Collections.Generic.Dictionary<string, KStream<K, V, TJVMK, TJVMV>>();
-            var map = _inner.DefaultBranch();
-            foreach (var item in map.KeySet())
+            using var map = _inner.DefaultBranch();
+            using var keySet = map.KeySet();
+            foreach (var item in keySet)
             {
-                var kStream = new KStream<K, V, TJVMK, TJVMV>(_factory, map.Get(item));
-                dict.Add(item, kStream);
+                using (item)
+                {
+                    var kStream = new KStream<K, V, TJVMK, TJVMV>(_factory, map.Get(item));
+                    dict.Add(item, kStream);
+                }
             }
 
             return dict;
@@ -108,11 +112,15 @@ namespace MASES.KNet.Streams.Kstream
             CheckDisposed();
             var dict = new System.Collections.Generic.Dictionary<string, KStream<K, V, TJVMK, TJVMV>>();
             if (arg0 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var map = _inner.DefaultBranch(arg0);
-            foreach (var item in map.KeySet())
+            using var map = _inner.DefaultBranch(arg0);
+            using var keySet = map.KeySet();
+            foreach (var item in keySet)
             {
-                var kStream = new KStream<K, V, TJVMK, TJVMV>(_factory, map.Get(item));
-                dict.Add(item, kStream);
+                using (item)
+                {
+                    var kStream = new KStream<K, V, TJVMK, TJVMV>(_factory, map.Get(item));
+                    dict.Add(item, kStream);
+                }
             }
 
             return dict;
@@ -125,11 +133,15 @@ namespace MASES.KNet.Streams.Kstream
         {
             CheckDisposed();
             var dict = new System.Collections.Generic.Dictionary<string, KStream<K, V, TJVMK, TJVMV>>();
-            var map = _inner.NoDefaultBranch();
-            foreach (var item in map.KeySet())
+            using var map = _inner.NoDefaultBranch();
+            using var keySet = map.KeySet();
+            foreach (var item in keySet)
             {
-                var kStream = new KStream<K, V, TJVMK, TJVMV>(_factory, map.Get(item));
-                dict.Add(item, kStream);
+                using (item)
+                {
+                    var kStream = new KStream<K, V, TJVMK, TJVMV>(_factory, map.Get(item));
+                    dict.Add(item, kStream);
+                }
             }
 
             return dict;

--- a/src/net/KNet/Specific/Streams/Kstream/KStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KStream.cs
@@ -1237,7 +1237,8 @@ namespace MASES.KNet.Streams.Kstream
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            _inner.To(arg0, arg1);
+            using Java.Lang.String jString = arg0;
+            _inner.To(jString, arg1);
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/kstream/KStream.html#to(java.lang.String)"/>
@@ -1246,7 +1247,8 @@ namespace MASES.KNet.Streams.Kstream
         public void To(string arg0)
         {
             CheckDisposed();
-            _inner.To(arg0);
+            using Java.Lang.String jString = arg0;
+            _inner.To(jString);
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/kstream/KStream.html#to(org.apache.kafka.streams.processor.TopicNameExtractor,org.apache.kafka.streams.kstream.Produced)"/>

--- a/src/net/KNet/Specific/Streams/Kstream/KeyValueMapper.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KeyValueMapper.cs
@@ -37,6 +37,19 @@ namespace MASES.KNet.Streams.Kstream
         ISerDes<K, TJVMK> _kSerializer = null;
         ISerDes<V, TJVMV> _vSerializer = null;
         ISerDes<VR, TJVMVR> _vrSerializer = null;
+        /// <inheritdoc/>
+        public KeyValueMapper()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(K, V)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMVR result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
 
         /// <summary>
         /// <see cref="IGenericSerDesFactory"/> can be used from any class inherited from <see cref="KeyValueMapper{K, V, VR, TJVMK, TJVMV, TJVMVR}"/>
@@ -58,6 +71,7 @@ namespace MASES.KNet.Streams.Kstream
                 return factory;
             }
         }
+
         /// <summary>
         /// Handler for <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/kstream/KeyValueMapper.html#apply(java.lang.Object,java.lang.Object)"/>
         /// </summary>
@@ -154,7 +168,17 @@ namespace MASES.KNet.Streams.Kstream
 
             var methodToExecute = (OnApply != null) ? OnApply : Apply;
             var res = methodToExecute(_kSerializer.Deserialize(null, arg0), _vSerializer.Deserialize(null, arg1));
-            return new Org.Apache.Kafka.Streams.KeyValue<TJVMKR, TJVMVR>(_krSerializer.Serialize(null, res.Item1), _vrSerializer.Serialize(null, res.Item2)); ;
+            var jKR = _krSerializer.Serialize(null, res.Item1);
+            var jVR = _vrSerializer.Serialize(null, res.Item2);
+            try
+            {
+                return new Org.Apache.Kafka.Streams.KeyValue<TJVMKR, TJVMVR>(jKR, jVR);
+            }
+            finally
+            {
+                (jKR as IDisposable)?.Dispose();
+                (jVR as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.KeyValueMapper{K, V, VR}.Apply(K, V)"/>
         public new virtual (KR, VR) Apply(K arg0, V arg1)
@@ -210,8 +234,18 @@ namespace MASES.KNet.Streams.Kstream
             var result = new ArrayList<Org.Apache.Kafka.Streams.KeyValue<TJVMKR, TJVMVR>>();
             foreach (var item in res)
             {
-                var data = new Org.Apache.Kafka.Streams.KeyValue<TJVMKR, TJVMVR>(_krSerializer.Serialize(null, item.Item1), _vrSerializer.Serialize(null, item.Item2));
-                result.Add(data);
+                var jKR = _krSerializer.Serialize(null, item.Item1);
+                var jVR = _vrSerializer.Serialize(null, item.Item2);
+                try
+                {
+                    var data = new Org.Apache.Kafka.Streams.KeyValue<TJVMKR, TJVMVR>(jKR, jVR);
+                    result.Add(data);
+                }
+                finally
+                {
+                    (jKR as IDisposable)?.Dispose();
+                    (jVR as IDisposable)?.Dispose();
+                }
             }
             return result;
         }

--- a/src/net/KNet/Specific/Streams/Kstream/KeyValueMapper.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KeyValueMapper.cs
@@ -80,12 +80,20 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public override TJVMVR Apply(TJVMK arg0, TJVMV arg1)
         {
-            _kSerializer ??= Factory?.BuildKeySerDes<K, TJVMK>();
-            _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
-            _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
-            var methodToExecute = (OnApply != null) ? OnApply : Apply;
-            var res = methodToExecute(_kSerializer.Deserialize(null, arg0), _vSerializer.Deserialize(null, arg1));
-            return _vrSerializer.Serialize(null, res);
+            try
+            {
+                _kSerializer ??= Factory?.BuildKeySerDes<K, TJVMK>();
+                _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
+                _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
+                var methodToExecute = (OnApply != null) ? OnApply : Apply;
+                var res = methodToExecute(_kSerializer.Deserialize(null, arg0), _vSerializer.Deserialize(null, arg1));
+                return _vrSerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.KeyValueMapper{K, V, VR}.Apply(K, V)"/>
         public virtual VR Apply(K arg0, V arg1)

--- a/src/net/KNet/Specific/Streams/Kstream/Merger.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Merger.cs
@@ -96,14 +96,23 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public sealed override TJVMV Apply(TJVMK arg0, TJVMV arg1, TJVMV arg2)
         {
-            _value1Set = _value2Set = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
-            _arg2 = arg2;
+            try
+            {
+                _value1Set = _value2Set = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
+                _arg2 = arg2;
 
-            V res = (OnApply != null) ? OnApply(this) : Apply();
-            _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
-            return _vSerializer.Serialize(null, res);
+                V res = (OnApply != null) ? OnApply(this) : Apply();
+                _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
+                return _vSerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+                (arg2 as IDisposable)?.Dispose();
+            }
         }
 
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.Merger{K, V}.Apply(K, V, V)"/>

--- a/src/net/KNet/Specific/Streams/Kstream/Merger.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Merger.cs
@@ -42,6 +42,20 @@ namespace MASES.KNet.Streams.Kstream
         ISerDes<K, TJVMK> _kSerializer = null;
         ISerDes<V, TJVMV> _vSerializer = null;
 
+        /// <inheritdoc/>
+        public Merger()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(TJVMK, TJVMV, TJVMV)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMV result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/Predicate.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Predicate.cs
@@ -72,11 +72,19 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public sealed override bool Test(TJVMK arg0, TJVMV arg1)
         {
-            _keySet = _valueSet = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
+            try
+            {
+                _keySet = _valueSet = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
 
-            return (OnTest != null) ? OnTest(this) : Test();
+                return (OnTest != null) ? OnTest(this) : Test();
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.Predicate{K, V}.Test(K, V)"/>
         public virtual bool Test()

--- a/src/net/KNet/Specific/Streams/Kstream/Printed.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Printed.cs
@@ -87,7 +87,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Printed{K, V, TJVMK, TJVMV}"/></returns>
         public static Printed<K, V, TJVMK, TJVMV> ToFile(string arg0)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Printed<TJVMK, TJVMV>.ToFile(arg0);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Printed<TJVMK, TJVMV>.ToFile(jString);
             return new Printed<K, V, TJVMK, TJVMV>(cons);
         }
         /// <summary>
@@ -125,7 +126,8 @@ namespace MASES.KNet.Streams.Kstream
         public Printed<K, V, TJVMK, TJVMV> WithLabel(string arg0)
         {
             CheckDisposed();
-            _inner?.WithLabel(arg0);
+            using Java.Lang.String jString = arg0;
+            _inner?.WithLabel(jString);
             return this;
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/Produced.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Produced.cs
@@ -98,7 +98,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Produced{K, V, TJVMK, TJVMV}"/></returns>
         public static Produced<K, V, TJVMK, TJVMV> As(string arg0)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Produced<TJVMK, TJVMV>.As(arg0);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Produced<TJVMK, TJVMV>.As(jString);
             return new Produced<K, V, TJVMK, TJVMV>(cons);
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/Reducer.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Reducer.cs
@@ -36,6 +36,20 @@ namespace MASES.KNet.Streams.Kstream
         bool _value2Set;
         ISerDes<V, TJVMV> _vSerializer = null;
 
+        /// <inheritdoc/>
+        public Reducer()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(TJVMV, TJVMV)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMV result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/Reducer.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Reducer.cs
@@ -86,13 +86,21 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public override TJVMV Apply(TJVMV arg0, TJVMV arg1)
         {
-            _value1Set = _value2Set = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
+            try
+            {
+                _value1Set = _value2Set = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
 
-            V res = (OnApply != null) ? OnApply(this) : Apply();
-            _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
-            return _vSerializer.Serialize(null, res);
+                V res = (OnApply != null) ? OnApply(this) : Apply();
+                _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
+                return _vSerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+            }
         }
 
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.Reducer{V}.Apply(V, V)"/>

--- a/src/net/KNet/Specific/Streams/Kstream/Repartitioned.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Repartitioned.cs
@@ -99,7 +99,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Repartitioned{K, V, TJVMK, TJVMV}"/></returns>
         public static Repartitioned<K, V, TJVMK, TJVMV> As(string arg0)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Repartitioned<TJVMK, TJVMV>.As(arg0);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Repartitioned<TJVMK, TJVMV>.As(jString);
             return new Repartitioned<K, V, TJVMK, TJVMV>(cons);
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/StreamJoined.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/StreamJoined.cs
@@ -89,7 +89,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="StreamJoined{K, V1, V2, TJVMK, TJVMV1, TJVMV2}"/></returns>
         public static StreamJoined<K, V1, V2, TJVMK, TJVMV1, TJVMV2> As(string arg0)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.StreamJoined<TJVMK, TJVMV1, TJVMV2>.As(arg0);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.StreamJoined<TJVMK, TJVMV1, TJVMV2>.As(jString);
             return new StreamJoined<K, V1, V2, TJVMK, TJVMV1, TJVMV2>(cons);
         }
         /// <summary>
@@ -202,7 +203,8 @@ namespace MASES.KNet.Streams.Kstream
         public StreamJoined<K, V1, V2, TJVMK, TJVMV1, TJVMV2> WithStoreName(string arg0)
         {
             CheckDisposed();
-            _inner?.WithStoreName(arg0);
+            using Java.Lang.String jString = arg0;
+            _inner?.WithStoreName(jString);
             return this;
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/Suppressed.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Suppressed.cs
@@ -86,7 +86,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="Suppressed{K, TJVMK}"/></returns>
         public static Suppressed<K, TJVMK> UntilTimeLimit(TimeSpan arg0, Org.Apache.Kafka.Streams.Kstream.Suppressed.BufferConfig arg1)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.Suppressed<TJVMK>.UntilTimeLimit(arg0, arg1);
+            using Java.Time.Duration duration = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.Suppressed<TJVMK>.UntilTimeLimit(duration, arg1);
             return new Suppressed<K, TJVMK>(cons);
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/TableJoined.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/TableJoined.cs
@@ -88,7 +88,8 @@ namespace MASES.KNet.Streams.Kstream
         /// <returns><see cref="TableJoined{K, KO, TJVMK, TJVMKO}"/></returns>
         public static TableJoined<K, KO, TJVMK, TJVMKO> As(string arg0)
         {
-            var cons = Org.Apache.Kafka.Streams.Kstream.TableJoined<TJVMK, TJVMKO>.As(arg0);
+            using Java.Lang.String jString = arg0;
+            var cons = Org.Apache.Kafka.Streams.Kstream.TableJoined<TJVMK, TJVMKO>.As(jString);
             return new TableJoined<K, KO, TJVMK, TJVMKO>(cons);
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/ValueJoiner.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueJoiner.cs
@@ -42,6 +42,20 @@ namespace MASES.KNet.Streams.Kstream
         ISerDes<V2, TJVMV2> _v2Serializer = null;
         ISerDes<VR, TJVMVR> _vrSerializer = null;
 
+        /// <inheritdoc/>
+        public ValueJoiner()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(TJVMV1, TJVMV2)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMVR result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/ValueJoiner.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueJoiner.cs
@@ -89,13 +89,21 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public sealed override TJVMVR Apply(TJVMV1 arg0, TJVMV2 arg1)
         {
-            _value1Set = _value2Set = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
+            try
+            {
+                _value1Set = _value2Set = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
 
-            VR res = (OnApply != null) ? OnApply(this) : Apply();
-            _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
-            return _vrSerializer.Serialize(null, res);
+                VR res = (OnApply != null) ? OnApply(this) : Apply();
+                _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
+                return _vrSerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.ValueJoiner{V1, V2, VR}.Apply(V1, V2)"/>>
         public virtual VR Apply()

--- a/src/net/KNet/Specific/Streams/Kstream/ValueJoinerWithKey.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueJoinerWithKey.cs
@@ -99,14 +99,23 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public override TJVMVR Apply(TJVMK1 arg0, TJVMV1 arg1, TJVMV2 arg2)
         {
-            _key1Set = _value1Set = _value2Set = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
-            _arg2 = arg2;
+            try
+            {
+                _key1Set = _value1Set = _value2Set = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
+                _arg2 = arg2;
 
-            VR res = (OnApply != null) ? OnApply(this) : Apply();
-            _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
-            return _vrSerializer.Serialize(null, res);
+                VR res = (OnApply != null) ? OnApply(this) : Apply();
+                _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
+                return _vrSerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+                (arg2 as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.ValueJoinerWithKey{K1, V1, V2, VR}.Apply(K1, V1, V2)"/>
         public virtual VR Apply()

--- a/src/net/KNet/Specific/Streams/Kstream/ValueJoinerWithKey.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueJoinerWithKey.cs
@@ -48,6 +48,20 @@ namespace MASES.KNet.Streams.Kstream
         ISerDes<V2, TJVMV2> _v2Serializer = null;
         ISerDes<VR, TJVMVR> _vrSerializer = null;
 
+        /// <inheritdoc/>
+        public ValueJoinerWithKey()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(TJVMK1, TJVMV1, TJVMV2)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMVR result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Kstream/ValueMapper.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueMapper.cs
@@ -75,12 +75,19 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public override TJVMVR Apply(TJVMV arg0)
         {
-            _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
-            _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
+            try
+            {
+                _vSerializer ??= Factory?.BuildValueSerDes<V, TJVMV>();
+                _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
 
-            var methodToExecute = (OnApply != null) ? OnApply : Apply;
-            var res = methodToExecute(_vSerializer.Deserialize(null, arg0));
-            return _vrSerializer.Serialize(null, res);
+                var methodToExecute = (OnApply != null) ? OnApply : Apply;
+                var res = methodToExecute(_vSerializer.Deserialize(null, arg0));
+                return _vrSerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.ValueMapper{V, VR}.Apply(V)"/>
         public virtual VR Apply(V arg0)

--- a/src/net/KNet/Specific/Streams/Kstream/ValueMapper.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueMapper.cs
@@ -35,6 +35,20 @@ namespace MASES.KNet.Streams.Kstream
         ISerDes<V, TJVMV> _vSerializer = null;
         ISerDes<VR, TJVMVR> _vrSerializer = null;
 
+        /// <inheritdoc/>
+        public ValueMapper()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(TJVMV)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMVR result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>
@@ -113,7 +127,15 @@ namespace MASES.KNet.Streams.Kstream
             var result = new ArrayList<TJVMVR>();
             foreach (var item in res)
             {
-                result.Add(_vrSerializer.Serialize(null, item));
+                var localValue = _vrSerializer.Serialize(null, item);
+                try
+                {
+                    result.Add(localValue);
+                }
+                finally
+                {
+                    (localValue as IDisposable)?.Dispose();
+                }
             }
             return result;
         }

--- a/src/net/KNet/Specific/Streams/Kstream/ValueMapperWithKey.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueMapperWithKey.cs
@@ -92,13 +92,21 @@ namespace MASES.KNet.Streams.Kstream
         /// <inheritdoc/>
         public override TJVMVR Apply(TJVMK arg0, TJVMV arg1)
         {
-            _keySet = _valueSet = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
+            try
+            {
+                _keySet = _valueSet = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
 
-            VR res = (OnApply != null) ? OnApply(this) : Apply();
-            _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
-            return _vrSerializer.Serialize(null, res);
+                VR res = (OnApply != null) ? OnApply(this) : Apply();
+                _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
+                return _vrSerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+            }
         }
         /// <inheritdoc cref="Org.Apache.Kafka.Streams.Kstream.ValueMapperWithKey{K, V, VR}.Apply(K, V)"/>
         public virtual VR Apply()

--- a/src/net/KNet/Specific/Streams/Kstream/ValueMapperWithKey.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueMapperWithKey.cs
@@ -45,6 +45,20 @@ namespace MASES.KNet.Streams.Kstream
         ISerDes<V, TJVMV> _vSerializer = null;
         ISerDes<VR, TJVMVR> _vrSerializer = null;
 
+        /// <inheritdoc/>
+        public ValueMapperWithKey()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(TJVMK, TJVMV)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMVR result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>
@@ -145,7 +159,15 @@ namespace MASES.KNet.Streams.Kstream
             var result = new ArrayList<TJVMVR>();
             foreach (var item in res)
             {
-                result.Add(_vrSerializer.Serialize(null, item));
+                var localValue = _vrSerializer.Serialize(null, item);
+                try
+                {
+                    result.Add(localValue);
+                }
+                finally
+                {
+                    (localValue as IDisposable)?.Dispose();
+                }
             }
             return result;
         }

--- a/src/net/KNet/Specific/Streams/Processor/Api/ProcessorContext.cs
+++ b/src/net/KNet/Specific/Streams/Processor/Api/ProcessorContext.cs
@@ -91,7 +91,8 @@ namespace MASES.KNet.Streams.Processor.Api
 		public void Forward<K, V, TJVMK, TJVMV>(Record<K, V, TJVMK, TJVMV> arg0, string arg1) where K : KForward where V : VForward where TJVMK : TJVMKForward where TJVMV : TJVMVForward
 		{
 			CheckDisposed();
-			_context.Forward<TJVMK, TJVMV>(arg0, arg1);
+            using Java.Lang.String jString = arg1;
+            _context.Forward<TJVMK, TJVMV>(arg0, jString);
 		}
 		/// <summary>
 		/// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/api/ProcessorContext.html#forward(org.apache.kafka.streams.processor.api.Record)"/>
@@ -120,7 +121,8 @@ namespace MASES.KNet.Streams.Processor.Api
 		public S GetStateStore<S>(string arg0) where S : Org.Apache.Kafka.Streams.Processor.IStateStore
 		{
 			CheckDisposed();
-			return _context.GetStateStore<S>(arg0);
+            using Java.Lang.String jString = arg0;
+            return _context.GetStateStore<S>(jString);
 		}
 		/// <summary>
 		/// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/api/ProcessingContext.html#stateDir()"/>
@@ -132,7 +134,7 @@ namespace MASES.KNet.Streams.Processor.Api
 		/// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/api/ProcessingContext.html#applicationId()"/>
 		/// </summary>
 		/// <returns><see cref="string"/></returns>
-		public string ApplicationId { get { CheckDisposed(); return _context.ApplicationId(); } }
+		public string ApplicationId { get { CheckDisposed(); using var appId = _context.ApplicationId(); return appId; } }
 		/// <summary>
 		/// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/api/ProcessingContext.html#appConfigs()"/>
 		/// </summary>
@@ -146,7 +148,8 @@ namespace MASES.KNet.Streams.Processor.Api
 		public Java.Util.Map<Java.Lang.String, object> AppConfigsWithPrefix(string arg0)
 		{
 			CheckDisposed();
-			return _context.AppConfigsWithPrefix(arg0);
+            using Java.Lang.String jString = arg0;
+            return _context.AppConfigsWithPrefix(jString);
 		}
 		/// <summary>
 		/// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/api/ProcessingContext.html#recordMetadata()"/>
@@ -157,7 +160,7 @@ namespace MASES.KNet.Streams.Processor.Api
 			get
 			{
 				CheckDisposed();
-				var opt = _context.RecordMetadata();
+				using var opt = _context.RecordMetadata();
 				return opt.IsPresent() ? opt.Get() : null;
 			}
 		}

--- a/src/net/KNet/Specific/Streams/Processor/Api/Record.cs
+++ b/src/net/KNet/Specific/Streams/Processor/Api/Record.cs
@@ -94,8 +94,15 @@ namespace MASES.KNet.Streams.Processor.Api
         {
             CheckDisposed();
             var serDes = _builder.BuildKeySerDes<NewK, TJVMNewK>();
-            var record = _record.WithKey(serDes.SerializeWithHeaders(_metadata?.Topic(), _record.Headers(), arg0));
-            return new Record<NewK, V, TJVMNewK, TJVMV>(_builder, record, _metadata);
+            using var topic = _metadata?.Topic();
+            using var headers = _record.Headers();
+            var key = serDes.SerializeWithHeaders(topic, headers, arg0);
+            try
+            {
+                var record = _record.WithKey(key);
+                return new Record<NewK, V, TJVMNewK, TJVMV>(_builder, record, _metadata);
+            }
+            finally { (key as IDisposable)?.Dispose(); }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/api/Record.html#withValue(java.lang.Object)"/>
@@ -108,8 +115,15 @@ namespace MASES.KNet.Streams.Processor.Api
         {
             CheckDisposed();
             var serDes = _builder.BuildValueSerDes<NewV, TJVMNewV>();
-            var record = _record.WithValue(serDes.SerializeWithHeaders(_metadata?.Topic(), _record.Headers(), arg0));
-            return new Record<K, NewV, TJVMK, TJVMNewV>(_builder, record, _metadata);
+            using var topic = _metadata?.Topic();
+            using var headers = _record.Headers();
+            var value = serDes.SerializeWithHeaders(topic, headers, arg0);
+            try
+            {
+                var record = _record.WithValue(value);
+                return new Record<K, NewV, TJVMK, TJVMNewV>(_builder, record, _metadata);
+            }
+            finally { (value as IDisposable)?.Dispose(); }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/api/Record.html#key()"/>
@@ -121,7 +135,17 @@ namespace MASES.KNet.Streams.Processor.Api
             {
                 CheckDisposed();
                 var serDes = _builder.BuildKeySerDes<K, TJVMK>();
-                return serDes.DeserializeWithHeaders(_metadata?.Topic(), _record.Headers(), _record.Key());
+                using var topic = _metadata?.Topic();
+                using var headers = _record.Headers();
+                var key = _record.Key();
+                try
+                {
+                    return serDes.DeserializeWithHeaders(topic, headers, key);
+                }
+                finally
+                {
+                    (key as IDisposable)?.Dispose();
+                }
             }
         }
         /// <summary>
@@ -134,7 +158,17 @@ namespace MASES.KNet.Streams.Processor.Api
             {
                 CheckDisposed();
                 var serDes = _builder.BuildValueSerDes<V, TJVMV>();
-                return serDes.DeserializeWithHeaders(_metadata?.Topic(), _record.Headers(), _record.Value());
+                using var topic = _metadata?.Topic();
+                using var headers = _record.Headers();
+                var value = _record.Value();
+                try
+                {
+                    return serDes.DeserializeWithHeaders(topic, headers, value);
+                }
+                finally
+                {
+                    (value as IDisposable)?.Dispose();
+                }
             }
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/Processor/StreamPartitioner.cs
+++ b/src/net/KNet/Specific/Streams/Processor/StreamPartitioner.cs
@@ -73,7 +73,7 @@ namespace MASES.KNet.Streams.Processor
         /// <summary>
         /// The <typeparamref name="K"/> content
         /// </summary>
-        public virtual K Key { get { if (!_keySet) { _kSerializer ??= Factory?.BuildKeySerDes<K,TJVMK>(); _key = _kSerializer.Deserialize(null, _arg1); _keySet = true; } return _key; } }
+        public virtual K Key { get { if (!_keySet) { _kSerializer ??= Factory?.BuildKeySerDes<K, TJVMK>(); _key = _kSerializer.Deserialize(null, _arg1); _keySet = true; } return _key; } }
         /// <summary>
         /// The <typeparamref name="V"/> content
         /// </summary>
@@ -85,31 +85,40 @@ namespace MASES.KNet.Streams.Processor
         /// <inheritdoc/>
         public override Optional<Set<Integer>> Partitions(Java.Lang.String arg0, TJVMK arg1, TJVMV arg2, int arg3)
         {
-            _keySet = _valueSet = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
-            _arg2 = arg2;
-            _arg3 = arg3;
-
-            var res = (OnPartitions != null) ? OnPartitions(this) : Partitions();
-            if (res == null || res.Count == 0) return Optional<Set<Integer>>.Empty();
-            using var scope = new JCOBridgeDisposeFastScope();
-            using HashSet<Integer> result = new HashSet<Integer>();
-            foreach (var item in res)
+            try
             {
-                if (item.HasValue)
+                _keySet = _valueSet = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
+                _arg2 = arg2;
+                _arg3 = arg3;
+
+                var res = (OnPartitions != null) ? OnPartitions(this) : Partitions();
+                if (res == null || res.Count == 0) return Optional<Set<Integer>>.Empty();
+                using var scope = new JCOBridgeDisposeFastScope();
+                using HashSet<Integer> result = new HashSet<Integer>();
+                foreach (var item in res)
                 {
-                    using (var integer = Integer.ValueOf(item.Value))
+                    if (item.HasValue)
                     {
-                        result.Add(integer);
+                        using (var integer = Integer.ValueOf(item.Value))
+                        {
+                            result.Add(integer);
+                        }
+                    }
+                    else
+                    {
+                        result.Add(null);
                     }
                 }
-                else
-                {
-                    result.Add(null);
-                }
+                return Optional<Set<Integer>>.Of(result);
             }
-            return Optional<Set<Integer>>.Of(result);
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+                (arg2 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// KNet override of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/StreamPartitioner.html#partitions(java.lang.String,java.lang.Object,java.lang.Object,int)"/>

--- a/src/net/KNet/Specific/Streams/Processor/StreamPartitionerNoValue.cs
+++ b/src/net/KNet/Specific/Streams/Processor/StreamPartitionerNoValue.cs
@@ -55,33 +55,42 @@ namespace MASES.KNet.Streams.Processor
         /// <inheritdoc/>
         public override Optional<Set<Integer>> Partitions(Java.Lang.String arg0, TJVMK arg1, Java.Lang.Void arg2, int arg3)
         {
-            _kSerializer ??= Factory?.BuildKeySerDes<K, TJVMK>();
-            _keySet = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
-            _arg3 = arg3;
-
-            var methodToExecute = (OnPartitions != null) ? OnPartitions : Partitions;
-
-            var res = methodToExecute(arg0, _kSerializer.Deserialize(arg0, arg1), arg3);
-            if (res == null || res.Count == 0) return Optional<Set<Integer>>.Empty();
-            using var scope = new JCOBridgeDisposeFastScope();
-            using HashSet<Integer> result = new HashSet<Integer>();
-            foreach (var item in res)
+            try
             {
-                if (item.HasValue)
+                _kSerializer ??= Factory?.BuildKeySerDes<K, TJVMK>();
+                _keySet = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
+                _arg3 = arg3;
+
+                var methodToExecute = (OnPartitions != null) ? OnPartitions : Partitions;
+
+                var res = methodToExecute(arg0, _kSerializer.Deserialize(arg0, arg1), arg3);
+                if (res == null || res.Count == 0) return Optional<Set<Integer>>.Empty();
+                using var scope = new JCOBridgeDisposeFastScope();
+                using HashSet<Integer> result = new HashSet<Integer>();
+                foreach (var item in res)
                 {
-                    using (var integer = Integer.ValueOf(item.Value))
+                    if (item.HasValue)
                     {
-                        result.Add(integer);
+                        using (var integer = Integer.ValueOf(item.Value))
+                        {
+                            result.Add(integer);
+                        }
+                    }
+                    else
+                    {
+                        result.Add(null);
                     }
                 }
-                else
-                {
-                    result.Add(null);
-                }
+                return Optional<Set<Integer>>.Of(result);
             }
-            return Optional<Set<Integer>>.Of(result);
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+                (arg2 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// KNet override of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/StreamPartitioner.html#partitions(java.lang.String,java.lang.Object,java.lang.Object,int)"/>

--- a/src/net/KNet/Specific/Streams/Processor/TopicNameExtractor.cs
+++ b/src/net/KNet/Specific/Streams/Processor/TopicNameExtractor.cs
@@ -78,12 +78,21 @@ namespace MASES.KNet.Streams.Processor
         /// <inheritdoc/>
         public sealed override Java.Lang.String Extract(TJVMK arg0, TJVMV arg1, Org.Apache.Kafka.Streams.Processor.RecordContext arg2)
         {
-            _keySet = _valueSet = false;
-            _arg0 = arg0;
-            _arg1 = arg1;
-            _context = arg2;
+            try
+            {
+                _keySet = _valueSet = false;
+                _arg0 = arg0;
+                _arg1 = arg1;
+                _context = arg2;
 
-            return (OnExtract != null) ? OnExtract(this) : Extract();
+                return (OnExtract != null) ? OnExtract(this) : Extract();
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+                (arg1 as IDisposable)?.Dispose();
+                // arg2 voluntary not disposed since the user can store it
+            }
         }
         /// <summary>
         /// KNet override of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/processor/TopicNameExtractor.html#extract(java.lang.Object,java.lang.Object,org.apache.kafka.streams.processor.RecordContext)"/>

--- a/src/net/KNet/Specific/Streams/State/KeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/KeyValueIterator.cs
@@ -178,7 +178,11 @@ namespace MASES.KNet.Streams.State
         {
             _keySerDes ??= Factory?.BuildKeySerDes<K, TJVMK>();
             var kk = _iterator.PeekNextKey();
-            return _keySerDes.Deserialize(null, kk);
+            try
+            {
+                return _keySerDes.Deserialize(null, kk);
+            }
+            finally { (kk as IDisposable)?.Dispose(); }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/KeyValueIterator.html#close()"/>

--- a/src/net/KNet/Specific/Streams/State/ReadOnlyKeyValueStore.cs
+++ b/src/net/KNet/Specific/Streams/State/ReadOnlyKeyValueStore.cs
@@ -17,6 +17,7 @@
 */
 
 using MASES.KNet.Serialization;
+using System;
 
 namespace MASES.KNet.Streams.State
 {
@@ -52,8 +53,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-
-            return new(factory, Store.Range(r0, r1));
+            try
+            {
+                return new(factory, Store.Range(r0, r1));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.html#get(java.lang.Object)"/>
@@ -68,15 +76,31 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var res = Store.Get(r0);
-            return _valueSerDes.Deserialize(null, res);
+            try
+            {
+                return _valueSerDes.Deserialize(null, res);
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (res as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.html#prefixScan(java.lang.Object,org.apache.kafka.common.serialization.Serializer)"/>
         /// </summary>
         /// <returns><see cref="KeyValueIterator{K, V, TJVMK, TJVMV}"/></returns>
-        public KeyValueIterator<K, V, TJVMK, TJVMV> PrefixScan<P, TJVMP>(P arg0, ISerDes<P, TJVMP> arg1) 
+        public KeyValueIterator<K, V, TJVMK, TJVMV> PrefixScan<P, TJVMP>(P arg0, ISerDes<P, TJVMP> arg1)
         {
-            return new(Factory, Store.PrefixScan(arg1.Serialize(null, arg0), arg1.KafkaSerializer));
+            var r0 = arg1.Serialize(null, arg0);
+            try
+            {
+                return new(Factory, Store.PrefixScan(r0, arg1.KafkaSerializer));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.html#reverseAll()"/>
@@ -96,8 +120,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-
-            return new(factory, Store.ReverseRange(r0, r1));
+            try
+            {
+                return new(factory, Store.ReverseRange(r0, r1));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
     }
 

--- a/src/net/KNet/Specific/Streams/State/ReadOnlySessionStore.cs
+++ b/src/net/KNet/Specific/Streams/State/ReadOnlySessionStore.cs
@@ -17,6 +17,7 @@
 */
 
 using MASES.KNet.Serialization;
+using System;
 
 namespace MASES.KNet.Streams.State
 {
@@ -42,7 +43,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.Fetch(r0, r1));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.Fetch(r0, r1));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#fetch(java.lang.Object)"/>
@@ -55,7 +64,14 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.Fetch(r0));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.Fetch(r0));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#fetchSession(java.lang.Object,java.time.Instant,java.time.Instant)"/>
@@ -72,7 +88,14 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var agg = Store.FetchSession(r0, arg1, arg2);
-            return _valueSerDes.Deserialize(null, agg);
+            try
+            {
+                return _valueSerDes.Deserialize(null, agg);
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#fetchSession(java.lang.Object,long,long)"/>
@@ -89,7 +112,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var agg = Store.FetchSession(r0, arg1, arg2);
-            return _valueSerDes.Deserialize(null, agg);
+            try
+            {
+                return _valueSerDes.Deserialize(null, agg);
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (agg as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#backwardFetch(java.lang.Object,java.lang.Object)"/>
@@ -104,7 +135,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFetch(r0, r1));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFetch(r0, r1));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#backwardFetch(java.lang.Object)"/>
@@ -117,7 +156,14 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFetch(r0));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFetch(r0));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#backwardFindSessions(java.lang.Object,java.time.Instant,java.time.Instant)"/>
@@ -132,7 +178,14 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, arg1, arg2));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, arg1, arg2));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#backwardFindSessions(java.lang.Object,java.lang.Object,java.time.Instant,java.time.Instant)"/>
@@ -149,7 +202,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, r1, arg2, arg3));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, r1, arg2, arg3));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#backwardFindSessions(java.lang.Object,java.lang.Object,long,long)"/>
@@ -166,7 +227,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, r1, arg2, arg3));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, r1, arg2, arg3));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#backwardFindSessions(java.lang.Object,long,long)"/>
@@ -181,7 +250,14 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, arg1, arg2));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, arg1, arg2));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#findSessions(java.lang.Object,java.time.Instant,java.time.Instant)"/>
@@ -196,7 +272,14 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, arg1, arg2));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.BackwardFindSessions(r0, arg1, arg2));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#findSessions(java.lang.Object,java.lang.Object,java.time.Instant,java.time.Instant)"/>
@@ -213,7 +296,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.FindSessions(r0, r1, arg2, arg3));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.FindSessions(r0, r1, arg2, arg3));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#findSessions(java.lang.Object,java.lang.Object,long,long)"/>
@@ -230,7 +321,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.FindSessions(r0, r1, arg2, arg3));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.FindSessions(r0, r1, arg2, arg3));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlySessionStore.html#findSessions(java.lang.Object,long,long)"/>
@@ -245,7 +344,14 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
-            return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.FindSessions(r0, arg1, arg2));
+            try
+            {
+                return new WindowedKeyValueIterator<K, AGG, TJVMK, TJVMAGG>(factory, Store.FindSessions(r0, arg1, arg2));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
     }
 

--- a/src/net/KNet/Specific/Streams/State/ReadOnlyWindowStore.cs
+++ b/src/net/KNet/Specific/Streams/State/ReadOnlyWindowStore.cs
@@ -17,6 +17,7 @@
 */
 
 using MASES.KNet.Serialization;
+using System;
 
 namespace MASES.KNet.Streams.State
 {
@@ -50,7 +51,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-            return new WindowedKeyValueIterator<K, V, TJVMK, TJVMV>(factory, Store.Fetch(r0, r1, arg2, arg3));
+            try
+            {
+                return new WindowedKeyValueIterator<K, V, TJVMK, TJVMV>(factory, Store.Fetch(r0, r1, arg2, arg3));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyWindowStore.html#fetchAll(java.time.Instant,java.time.Instant)"/>
@@ -77,7 +86,14 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
-            return new WindowStoreIterator<V, TJVMV>(factory, Store.Fetch(r0, arg1, arg2));
+            try
+            {
+                return new WindowStoreIterator<V, TJVMV>(factory, Store.Fetch(r0, arg1, arg2));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyWindowStore.html#fetch(java.lang.Object,long)"/>
@@ -93,7 +109,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var agg = Store.Fetch(r0, arg1);
-            return _valueSerDes.Deserialize(null, agg);
+            try
+            {
+                return _valueSerDes.Deserialize(null, agg);
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (agg as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyWindowStore.html#backwardAll()"/>
@@ -116,7 +140,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-            return new WindowedKeyValueIterator<K, V, TJVMK, TJVMV>(factory, Store.BackwardFetch(r0, r1, arg2, arg3));
+            try
+            {
+                return new WindowedKeyValueIterator<K, V, TJVMK, TJVMV>(factory, Store.BackwardFetch(r0, r1, arg2, arg3));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyWindowStore.html#backwardFetchAll(java.time.Instant,java.time.Instant)"/>
@@ -143,7 +175,14 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
-            return new WindowStoreIterator<V, TJVMV>(factory, Store.BackwardFetch(r0, arg1, arg2));
+            try
+            {
+                return new WindowStoreIterator<V, TJVMV>(factory, Store.BackwardFetch(r0, arg1, arg2));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
     }
 

--- a/src/net/KNet/Specific/Streams/State/TimestampedKeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/TimestampedKeyValueIterator.cs
@@ -167,7 +167,11 @@ namespace MASES.KNet.Streams.State
         {
             _keySerDes ??= Factory?.BuildKeySerDes<K, TJVMK>();
             var kk = _iterator.PeekNextKey();
-            return _keySerDes.Deserialize(null, kk);
+            try
+            {
+                return _keySerDes.Deserialize(null, kk);
+            }
+            finally { (kk as IDisposable)?.Dispose(); }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/KeyValueIterator.html#close()"/>

--- a/src/net/KNet/Specific/Streams/State/TimestampedKeyValueStore.cs
+++ b/src/net/KNet/Specific/Streams/State/TimestampedKeyValueStore.cs
@@ -17,6 +17,7 @@
 */
 
 using MASES.KNet.Serialization;
+using System;
 
 namespace MASES.KNet.Streams.State
 {
@@ -52,8 +53,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-
-            return new(factory, Store.Range(r0, r1));
+            try
+            {
+                return new(factory, Store.Range(r0, r1));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.html#get(java.lang.Object)"/>
@@ -67,7 +75,14 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var res = Store.Get(r0);
-            return new ValueAndTimestamp<V, TJVMV>(factory, res);
+            try
+            {
+                return new ValueAndTimestamp<V, TJVMV>(factory, res);
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.html#prefixScan(java.lang.Object,org.apache.kafka.common.serialization.Serializer)"/>
@@ -75,7 +90,15 @@ namespace MASES.KNet.Streams.State
         /// <returns><see cref="TimestampedKeyValueIterator{K, V, TJVMK, TJVMV}"/></returns>
         public TimestampedKeyValueIterator<K, V, TJVMK, TJVMV> PrefixScan<P, TJVMP>(P arg0, ISerDes<P, TJVMP> arg1)
         {
-            return new(Factory, Store.PrefixScan(arg1.Serialize(null, arg0), arg1.KafkaSerializer));
+            var r0 = arg1.Serialize(null, arg0);
+            try
+            {
+                return new(Factory, Store.PrefixScan(r0, arg1.KafkaSerializer));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.html#reverseAll()"/>
@@ -95,8 +118,15 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-
-            return new(factory, Store.ReverseRange(r0, r1));
+            try
+            {
+                return new(factory, Store.ReverseRange(r0, r1));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
     }
 

--- a/src/net/KNet/Specific/Streams/State/TimestampedWindowStore.cs
+++ b/src/net/KNet/Specific/Streams/State/TimestampedWindowStore.cs
@@ -17,6 +17,7 @@
 */
 
 using MASES.KNet.Serialization;
+using System;
 
 namespace MASES.KNet.Streams.State
 {
@@ -50,8 +51,14 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-
+            try { 
             return new(factory, Store.Fetch(r0, r1, arg2, arg3));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyWindowStore.html#fetchAll(java.time.Instant,java.time.Instant)"/>
@@ -78,7 +85,14 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
+            try
+            { 
             return new(factory, Store.Fetch(r0, arg1, arg2));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyWindowStore.html#fetch(java.lang.Object,long)"/>
@@ -93,7 +107,14 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var agg = Store.Fetch(r0, arg1);
+            try
+            { 
             return new ValueAndTimestamp<V, TJVMV>(factory, agg);
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyWindowStore.html#backwardAll()"/>
@@ -116,8 +137,14 @@ namespace MASES.KNet.Streams.State
 
             var r0 = _keySerDes.Serialize(null, arg0);
             var r1 = _keySerDes.Serialize(null, arg1);
-
+            try { 
             return new(factory, Store.BackwardFetch(r0, r1, arg2, arg3));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+                (r1 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/ReadOnlyWindowStore.html#backwardFetchAll(java.time.Instant,java.time.Instant)"/>
@@ -144,8 +171,13 @@ namespace MASES.KNet.Streams.State
             var _keySerDes = factory?.BuildKeySerDes<K, TJVMK>();
 
             var r0 = _keySerDes.Serialize(null, arg0);
-
+            try { 
             return new(factory, Store.BackwardFetch(r0, arg1, arg2));
+            }
+            finally
+            {
+                (r0 as IDisposable)?.Dispose();
+            }
         }
     }
 

--- a/src/net/KNet/Specific/Streams/State/ValueAndTimestamp.cs
+++ b/src/net/KNet/Specific/Streams/State/ValueAndTimestamp.cs
@@ -97,7 +97,11 @@ namespace MASES.KNet.Streams.State
                 CheckDisposed();
                 _valueSerDes ??= _factory?.BuildKeySerDes<V, TJVMV>();
                 var vv = _valueAndTimestamp.Value();
-                return _valueSerDes.Deserialize(null, vv);
+                try
+                {
+                    return _valueSerDes.Deserialize(null, vv);
+                }
+                finally { (vv as IDisposable)?.Dispose(); }
             }
         }
     }

--- a/src/net/KNet/Specific/Streams/State/WindowedKeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/WindowedKeyValueIterator.cs
@@ -168,7 +168,11 @@ namespace MASES.KNet.Streams.State
         public Windowed<K, TJVMK> PeekNextKey()
         {
             var kk = _iterator.PeekNextKey();
-            return new Windowed<K, TJVMK>(Factory, kk);
+            try
+            {
+                return new Windowed<K, TJVMK>(Factory, kk);
+            }
+            finally { (kk as IDisposable)?.Dispose(); }
         }
         /// <summary>
         /// KNet implementation of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/state/KeyValueIterator.html#close()"/>

--- a/src/net/KNet/Specific/Streams/StreamsBuilder.cs
+++ b/src/net/KNet/Specific/Streams/StreamsBuilder.cs
@@ -119,7 +119,8 @@ namespace MASES.KNet.Streams
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
             if (arg2 is IGenericSerDesFactoryApplier applier2) applier2.Factory = _factory;
-            return new GlobalKTable<K, V, TJVMK, TJVMV>(_factory, _builder.GlobalTable<TJVMK, TJVMV>(arg0, arg1, arg2));
+            using Java.Lang.String jArg0 = arg0;
+            return new GlobalKTable<K, V, TJVMK, TJVMV>(_factory, _builder.GlobalTable<TJVMK, TJVMV>(jArg0, arg1, arg2));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#globalTable(java.lang.String,org.apache.kafka.streams.kstream.Consumed)"/>
@@ -135,7 +136,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            return new GlobalKTable<K, V, TJVMK, TJVMV>(_factory, _builder.GlobalTable<TJVMK, TJVMV>(arg0, arg1));
+            using Java.Lang.String jArg0 = arg0;
+            return new GlobalKTable<K, V, TJVMK, TJVMV>(_factory, _builder.GlobalTable<TJVMK, TJVMV>(jArg0, arg1));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#globalTable(java.lang.String,org.apache.kafka.streams.kstream.Materialized)"/>
@@ -151,7 +153,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            return new GlobalKTable<K, V, TJVMK, TJVMV>(_factory, _builder.GlobalTable<TJVMK, TJVMV>(arg0, arg1));
+            using Java.Lang.String jArg0 = arg0;
+            return new GlobalKTable<K, V, TJVMK, TJVMV>(_factory, _builder.GlobalTable<TJVMK, TJVMV>(jArg0, arg1));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#globalTable(java.lang.String)"/>
@@ -165,7 +168,8 @@ namespace MASES.KNet.Streams
         public GlobalKTable<K, V, TJVMK, TJVMV> GlobalTable<K, V, TJVMK, TJVMV>(string arg0)
         {
             CheckDisposed();
-            return new GlobalKTable<K, V, TJVMK, TJVMV>(_factory, _builder.GlobalTable<TJVMK, TJVMV>(arg0));
+            using Java.Lang.String jArg0 = arg0;
+            return new GlobalKTable<K, V, TJVMK, TJVMV>(_factory, _builder.GlobalTable<TJVMK, TJVMV>(jArg0));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#stream(java.lang.String,org.apache.kafka.streams.kstream.Consumed)"/>
@@ -181,7 +185,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            return new KStream<K, V, TJVMK, TJVMV>(_factory, _builder.Stream<TJVMK, TJVMV>(arg0));
+            using Java.Lang.String jArg0 = arg0;
+            return new KStream<K, V, TJVMK, TJVMV>(_factory, _builder.Stream<TJVMK, TJVMV>(jArg0));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#stream(java.lang.String)"/>
@@ -195,7 +200,8 @@ namespace MASES.KNet.Streams
         public KStream<K, V, TJVMK, TJVMV> Stream<K, V, TJVMK, TJVMV>(string arg0)
         {
             CheckDisposed();
-            return new KStream<K, V, TJVMK, TJVMV>(_factory, _builder.Stream<TJVMK, TJVMV>(arg0));
+            using Java.Lang.String jArg0 = arg0;
+            return new KStream<K, V, TJVMK, TJVMV>(_factory, _builder.Stream<TJVMK, TJVMV>(jArg0));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#stream(java.util.Collection,org.apache.kafka.streams.kstream.Consumed)"/>
@@ -211,7 +217,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            return new KStream<K, V, TJVMK, TJVMV>(_factory, _builder.Stream<TJVMK, TJVMV>(arg0.ToJVMCollection<Java.Lang.String, string>(), arg1));
+            using var collection = arg0.ToJVMCollection<Java.Lang.String, string>();
+            return new KStream<K, V, TJVMK, TJVMV>(_factory, _builder.Stream<TJVMK, TJVMV>(collection, arg1));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#stream(java.util.Collection)"/>
@@ -225,7 +232,8 @@ namespace MASES.KNet.Streams
         public KStream<K, V, TJVMK, TJVMV> Stream<K, V, TJVMK, TJVMV>(System.Collections.Generic.IEnumerable<string> arg0)
         {
             CheckDisposed();
-            return new KStream<K, V, TJVMK, TJVMV>(_factory, _builder.Stream<TJVMK, TJVMV>(arg0.ToJVMCollection<Java.Lang.String, string>()));
+            using var collection = arg0.ToJVMCollection<Java.Lang.String, string>();
+            return new KStream<K, V, TJVMK, TJVMV>(_factory, _builder.Stream<TJVMK, TJVMV>(collection));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#stream(java.util.regex.Pattern,org.apache.kafka.streams.kstream.Consumed)"/>
@@ -273,7 +281,8 @@ namespace MASES.KNet.Streams
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
             if (arg2 is IGenericSerDesFactoryApplier applier2) applier2.Factory = _factory;
-            return new KTable<K, V, TJVMK, TJVMV>(_factory, _builder.Table<TJVMK, TJVMV>(arg0, arg1, arg2));
+            using Java.Lang.String jArg0 = arg0;
+            return new KTable<K, V, TJVMK, TJVMV>(_factory, _builder.Table<TJVMK, TJVMV>(jArg0, arg1, arg2));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#table(java.lang.String,org.apache.kafka.streams.kstream.Consumed)"/>
@@ -289,7 +298,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            return new KTable<K, V, TJVMK, TJVMV>(_factory, _builder.Table<TJVMK, TJVMV>(arg0, arg1));
+            using Java.Lang.String jArg0 = arg0;
+            return new KTable<K, V, TJVMK, TJVMV>(_factory, _builder.Table<TJVMK, TJVMV>(jArg0, arg1));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#table(java.lang.String,org.apache.kafka.streams.kstream.Materialized)"/>
@@ -305,7 +315,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            return new KTable<K, V, TJVMK, TJVMV>(_factory, _builder.Table<TJVMK, TJVMV>(arg0, arg1));
+            using Java.Lang.String jArg0 = arg0;
+            return new KTable<K, V, TJVMK, TJVMV>(_factory, _builder.Table<TJVMK, TJVMV>(jArg0, arg1));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#table(java.lang.String)"/>
@@ -319,7 +330,8 @@ namespace MASES.KNet.Streams
         public KTable<K, V, TJVMK, TJVMV> Table<K, V, TJVMK, TJVMV>(string arg0)
         {
             CheckDisposed();
-            return new KTable<K, V, TJVMK, TJVMV>(_factory, _builder.Table<TJVMK, TJVMV>(arg0));
+            using Java.Lang.String jArg0 = arg0;
+            return new KTable<K, V, TJVMK, TJVMV>(_factory, _builder.Table<TJVMK, TJVMV>(jArg0));
         }
         /// <summary>
         /// <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/4.2.0/org/apache/kafka/streams/StreamsBuilder.html#addStateStore(org.apache.kafka.streams.state.StoreBuilder)"/>

--- a/src/net/KNet/Specific/Streams/TimestampedKeyValue.cs
+++ b/src/net/KNet/Specific/Streams/TimestampedKeyValue.cs
@@ -53,8 +53,13 @@ namespace MASES.KNet.Streams
             if (fromPrefetched)
             {
                 _keySerDes ??= _factory?.BuildKeySerDes<K, TJVMK>();
-                _key = _keySerDes.Deserialize(null, _inner.Key);
-                _keyStored = true;
+                var key = _inner.Key;
+                try
+                {
+                    _key = _keySerDes.Deserialize(null, key);
+                    _keyStored = true;
+                }
+                finally { (key as IDisposable)?.Dispose(); }
             }
         }
 
@@ -99,8 +104,13 @@ namespace MASES.KNet.Streams
                 if (!_keyStored)
                 {
                     _keySerDes ??= _factory?.BuildKeySerDes<K, TJVMK>();
-                    _key = _keySerDes.Deserialize(null, _inner.Key);
-                    _keyStored = true;
+                    var key = _inner.Key;
+                    try
+                    {
+                        _key = _keySerDes.Deserialize(null, key);
+                        _keyStored = true;
+                    }
+                    finally { (key as IDisposable)?.Dispose(); }
                 }
                 return _key;
             }

--- a/src/net/KNet/Specific/Streams/Topology.cs
+++ b/src/net/KNet/Specific/Streams/Topology.cs
@@ -112,7 +112,9 @@ namespace MASES.KNet.Streams
         public Topology AddSink<K, V>(string arg0, string arg1, ISerializer<K, byte[]> arg2, ISerializer<V, byte[]> arg3, params string[] arg4)
         {
             CheckDisposed();
-            var top = _topology.AddSink(arg0, arg1, arg2.KafkaSerializer, arg3.KafkaSerializer, arg4.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg0 = arg0;
+            using Java.Lang.String jArg1 = arg1;
+            var top = _topology.AddSink(jArg0, jArg1, arg2.KafkaSerializer, arg3.KafkaSerializer, arg4.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -133,7 +135,9 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg4 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = _topology.AddSink(arg0, arg1, arg2.KafkaSerializer, arg3.KafkaSerializer, arg4, arg5.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg0 = arg0;
+            using Java.Lang.String jArg1 = arg1;
+            var top = _topology.AddSink(jArg0, jArg1, arg2.KafkaSerializer, arg3.KafkaSerializer, arg4, arg5.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -152,7 +156,10 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg2 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = (arg3.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSink", arg0, arg1, arg2) : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1, arg2, arg3);
+            using Java.Lang.String jArg0 = arg0;
+            using Java.Lang.String jArg1 = arg1;
+            var top = (arg3.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSink", jArg0, jArg1, arg2) 
+                                         : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", jArg0, jArg1, arg2, arg3);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -168,7 +175,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = _topology.AddSink<byte[], byte[], byte[], byte[]>(arg0, arg1, arg2.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg0 = arg0;
+            var top = _topology.AddSink<byte[], byte[], byte[], byte[]>(jArg0, arg1, arg2.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -186,7 +194,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = _topology.AddSink(arg0, arg1, arg2.KafkaSerializer, arg3.KafkaSerializer, arg4.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg0 = arg0;
+            var top = _topology.AddSink(jArg0, arg1, arg2.KafkaSerializer, arg3.KafkaSerializer, arg4.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -207,7 +216,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = _topology.AddSink(arg0, arg1, arg2.KafkaSerializer, arg3.KafkaSerializer, arg4, arg5.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg0 = arg0;
+            var top = _topology.AddSink(jArg0, arg1, arg2.KafkaSerializer, arg3.KafkaSerializer, arg4, arg5.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -227,7 +237,8 @@ namespace MASES.KNet.Streams
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
             if (arg2 is IGenericSerDesFactoryApplier applier1) applier1.Factory = _factory;
-            var top = _topology.AddSink<byte[], byte[], byte[], byte[], byte[], byte[]>(arg0, arg1, arg2, arg3.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg0 = arg0;
+            var top = _topology.AddSink<byte[], byte[], byte[], byte[], byte[], byte[]>(jArg0, arg1, arg2, arg3.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -240,7 +251,9 @@ namespace MASES.KNet.Streams
         public Topology AddSink(string arg0, string arg1, params string[] arg2)
         {
             CheckDisposed();
-            var top = _topology.AddSink(arg0, arg1, arg2.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg0 = arg0;
+            using Java.Lang.String jArg1 = arg1;
+            var top = _topology.AddSink(jArg0, jArg1, arg2.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -252,7 +265,8 @@ namespace MASES.KNet.Streams
         public Topology AddSource(string arg0, params string[] arg1)
         {
             CheckDisposed();
-            var top = _topology.AddSource(arg0, arg1.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg0 = arg0;
+            var top = _topology.AddSource(jArg0, arg1.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -264,7 +278,8 @@ namespace MASES.KNet.Streams
         public Topology AddSource(string arg0, Java.Util.Regex.Pattern arg1)
         {
             CheckDisposed();
-            var top = _topology.AddSource(arg0, arg1);
+            using Java.Lang.String jArg0 = arg0;
+            var top = _topology.AddSource(jArg0, arg1);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -278,7 +293,9 @@ namespace MASES.KNet.Streams
         public Topology AddSource(string arg0, IDeserializer<object, byte[]> arg1, IDeserializer<object, byte[]> arg2, params string[] arg3)
         {
             CheckDisposed();
-            var top = (arg3.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1.KafkaDeserializer, arg2.KafkaDeserializer) : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1.KafkaDeserializer, arg2.KafkaDeserializer, arg3);
+            using Java.Lang.String jArg0 = arg0;
+            var top = (arg3.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", jArg0, arg1.KafkaDeserializer, arg2.KafkaDeserializer) 
+                                         : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", jArg0, arg1.KafkaDeserializer, arg2.KafkaDeserializer, arg3);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -292,7 +309,8 @@ namespace MASES.KNet.Streams
         public Topology AddSource(string arg0, IDeserializer<object, byte[]> arg1, IDeserializer<object, byte[]> arg2, Java.Util.Regex.Pattern arg3)
         {
             CheckDisposed();
-            var top = _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1.KafkaDeserializer, arg2.KafkaDeserializer, arg3);
+            using Java.Lang.String jArg0 = arg0;
+            var top = _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", jArg0, arg1.KafkaDeserializer, arg2.KafkaDeserializer, arg3);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -306,7 +324,9 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg0 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = (arg2.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1) : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1, arg2);
+            using Java.Lang.String jArg1 = arg1;
+            var top = (arg2.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, jArg1) 
+                                         : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, jArg1, arg2);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -320,7 +340,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg0 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = _topology.AddSource(arg0, arg1, arg2);
+            using Java.Lang.String jArg1 = arg1;
+            var top = _topology.AddSource(arg0, jArg1, arg2);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -333,7 +354,8 @@ namespace MASES.KNet.Streams
         public Topology AddSource(Org.Apache.Kafka.Streams.AutoOffsetReset arg0, string arg1, params string[] arg2)
         {
             CheckDisposed();
-            var top = _topology.AddSource(arg0, arg1, arg2.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg1 = arg1;
+            var top = _topology.AddSource(arg0, jArg1, arg2.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -346,7 +368,8 @@ namespace MASES.KNet.Streams
         public Topology AddSource(Org.Apache.Kafka.Streams.AutoOffsetReset arg0, string arg1, Java.Util.Regex.Pattern arg2)
         {
             CheckDisposed();
-            var top = _topology.AddSource(arg0, arg1, arg2);
+            using Java.Lang.String jArg1 = arg1;
+            var top = _topology.AddSource(arg0, jArg1, arg2);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -361,7 +384,9 @@ namespace MASES.KNet.Streams
         public Topology AddSource(Org.Apache.Kafka.Streams.AutoOffsetReset arg0, string arg1, IDeserializer<object, byte[]> arg2, IDeserializer<object, byte[]> arg3, params string[] arg4)
         {
             CheckDisposed();
-            var top = (arg4.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1, arg2.KafkaDeserializer, arg3.KafkaDeserializer) : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1, arg2.KafkaDeserializer, arg3.KafkaDeserializer, arg4);
+            using Java.Lang.String jArg1 = arg1;
+            var top = (arg4.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, jArg1, arg2.KafkaDeserializer, arg3.KafkaDeserializer) 
+                                         : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, jArg1, arg2.KafkaDeserializer, arg3.KafkaDeserializer, arg4);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -376,7 +401,8 @@ namespace MASES.KNet.Streams
         public Topology AddSource(Org.Apache.Kafka.Streams.AutoOffsetReset arg0, string arg1, IDeserializer<object, byte[]> arg2, IDeserializer<object, byte[]> arg3, Java.Util.Regex.Pattern arg4)
         {
             CheckDisposed();
-            var top = _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1, arg2.KafkaDeserializer, arg3.KafkaDeserializer, arg4);
+            using Java.Lang.String jArg1 = arg1;
+            var top = _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, jArg1, arg2.KafkaDeserializer, arg3.KafkaDeserializer, arg4);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -393,7 +419,9 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg2 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = (arg5.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1, arg2, arg3.KafkaDeserializer, arg4.KafkaDeserializer) : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1, arg2, arg3.KafkaDeserializer, arg4.KafkaDeserializer, arg5);
+            using Java.Lang.String jArg1 = arg1;
+            var top = (arg5.Length == 0) ? _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, jArg1, arg2, arg3.KafkaDeserializer, arg4.KafkaDeserializer) 
+                                         : _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, jArg1, arg2, arg3.KafkaDeserializer, arg4.KafkaDeserializer, arg5);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -410,7 +438,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg2 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, arg1, arg2, arg3.KafkaDeserializer, arg4.KafkaDeserializer, arg5);
+            using Java.Lang.String jArg1 = arg1;
+            var top = _topology.IExecute<Org.Apache.Kafka.Streams.Topology>("addSource", arg0, jArg1, arg2, arg3.KafkaDeserializer, arg4.KafkaDeserializer, arg5);
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -425,7 +454,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = _topology.AddSource(arg0, arg1, arg2, arg3.ToJVMArray<Java.Lang.String, string>());
+            using Java.Lang.String jArg2 = arg2;
+            var top = _topology.AddSource(arg0, arg1, jArg2, arg3.ToJVMArray<Java.Lang.String, string>());
             return new Topology(top, _factory);
         }
         /// <summary>
@@ -440,7 +470,8 @@ namespace MASES.KNet.Streams
         {
             CheckDisposed();
             if (arg1 is IGenericSerDesFactoryApplier applier) applier.Factory = _factory;
-            var top = _topology.AddSource(arg0, arg1, arg2, arg3);
+            using Java.Lang.String jArg2 = arg2;
+            var top = _topology.AddSource(arg0, arg1, jArg2, arg3);
             return new Topology(top, _factory);
         }
 

--- a/src/net/KNet/Specific/Streams/Utils/BiFunction.cs
+++ b/src/net/KNet/Specific/Streams/Utils/BiFunction.cs
@@ -36,6 +36,20 @@ namespace MASES.KNet.Streams.Utils
         ISerDes<KO, TJVMKO> _keyOutputSerializer = null;
         ISerDes<V, TJVMV> _valueSerializer = null;
 
+        /// <inheritdoc/>
+        public BiFunction()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(TJVMK, TJVMV)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMKO result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>
@@ -45,18 +59,26 @@ namespace MASES.KNet.Streams.Utils
         /// <inheritdoc/>
         public override TJVMKO Apply(TJVMK o1, TJVMV o2)
         {
-            IGenericSerDesFactory factory = null;
-            if (this is IGenericSerDesFactoryApplier applier && (factory = applier.Factory) == null)
+            try
             {
-                throw new InvalidOperationException("The serialization factory instance was not set.");
-            }
-            _keySerializer ??= factory?.BuildKeySerDes<K, TJVMK>();
-            _keyOutputSerializer ??= factory?.BuildKeySerDes<KO, TJVMKO>();
-            _valueSerializer ??= factory?.BuildValueSerDes<V, TJVMV>();
-            var methodToExecute = (OnApply != null) ? OnApply : Apply;
-            var res = methodToExecute(_keySerializer.Deserialize(null, o1), _valueSerializer.Deserialize(null, o2));
+                IGenericSerDesFactory factory = null;
+                if (this is IGenericSerDesFactoryApplier applier && (factory = applier.Factory) == null)
+                {
+                    throw new InvalidOperationException("The serialization factory instance was not set.");
+                }
+                _keySerializer ??= factory?.BuildKeySerDes<K, TJVMK>();
+                _keyOutputSerializer ??= factory?.BuildKeySerDes<KO, TJVMKO>();
+                _valueSerializer ??= factory?.BuildValueSerDes<V, TJVMV>();
+                var methodToExecute = (OnApply != null) ? OnApply : Apply;
+                var res = methodToExecute(_keySerializer.Deserialize(null, o1), _valueSerializer.Deserialize(null, o2));
 
-            return _keyOutputSerializer.Serialize(null, res);
+                return _keyOutputSerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (o1 as IDisposable)?.Dispose();
+                (o2 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// Executes the Function action in the CLR

--- a/src/net/KNet/Specific/Streams/Utils/Function.cs
+++ b/src/net/KNet/Specific/Streams/Utils/Function.cs
@@ -33,6 +33,20 @@ namespace MASES.KNet.Streams.Utils
         ISerDes<KO, TJVMKO> _keySerializer = null;
         ISerDes<V, TJVMV> _valueSerializer = null;
 
+        /// <inheritdoc/>
+        public Function()
+        {
+            OnApplyDispose = DisposeResult;
+        }
+        /// <summary>
+        /// Disposes the results of the <see cref="Apply(TJVMV)"/> or <see cref="OnApply"/> operations
+        /// </summary>
+        /// <param name="result">The result to be disposed</param>
+        protected virtual void DisposeResult(TJVMKO result)
+        {
+            (result as IDisposable)?.Dispose();
+        }
+
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>
@@ -42,17 +56,24 @@ namespace MASES.KNet.Streams.Utils
         /// <inheritdoc/>
         public override TJVMKO Apply(TJVMV arg0)
         {
-            IGenericSerDesFactory factory = null;
-            if (this is IGenericSerDesFactoryApplier applier && (factory = applier.Factory) == null)
+            try
             {
-                throw new InvalidOperationException("The serialization factory instance was not set.");
-            }
-            _keySerializer ??= factory?.BuildKeySerDes<KO, TJVMKO>();
-            _valueSerializer ??= factory?.BuildValueSerDes<V, TJVMV>();
-            var methodToExecute = (OnApply != null) ? OnApply : Apply;
-            var res = methodToExecute(_valueSerializer.Deserialize(null, arg0));
+                IGenericSerDesFactory factory = null;
+                if (this is IGenericSerDesFactoryApplier applier && (factory = applier.Factory) == null)
+                {
+                    throw new InvalidOperationException("The serialization factory instance was not set.");
+                }
+                _keySerializer ??= factory?.BuildKeySerDes<KO, TJVMKO>();
+                _valueSerializer ??= factory?.BuildValueSerDes<V, TJVMV>();
+                var methodToExecute = (OnApply != null) ? OnApply : Apply;
+                var res = methodToExecute(_valueSerializer.Deserialize(null, arg0));
 
-            return _keySerializer.Serialize(null, res);
+                return _keySerializer.Serialize(null, res);
+            }
+            finally
+            {
+                (arg0 as IDisposable)?.Dispose();
+            }
         }
         /// <summary>
         /// Executes the Function action in the CLR

--- a/src/net/KNet/Specific/Streams/WindowedKeyValue.cs
+++ b/src/net/KNet/Specific/Streams/WindowedKeyValue.cs
@@ -111,8 +111,15 @@ namespace MASES.KNet.Streams
                 {
                     _valueSerDes ??= _factory?.BuildValueSerDes<V, TJVMV>();
                     var kk = _valueInner.Value;
-                    _value = _valueSerDes.Deserialize(null, kk);
-                    _valueStored = true;
+                    try
+                    {
+                        _value = _valueSerDes.Deserialize(null, kk);
+                        _valueStored = true;
+                    }
+                    finally
+                    {
+                        (kk as IDisposable)?.Dispose();
+                    }
                 }
                 return _value;
             }

--- a/src/net/KNetCLI/KNetCLI.csproj
+++ b/src/net/KNetCLI/KNetCLI.csproj
@@ -30,7 +30,7 @@
 		<None Include="..\..\documentation\articles\usageCLI.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="MASES.JNetCLICore" Version="2.6.9-rc93" />
+		<PackageReference Include="MASES.JNetCLICore" Version="2.6.9-rc94" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/net/KNetConnect/KNetConnect.csproj
+++ b/src/net/KNetConnect/KNetConnect.csproj
@@ -30,7 +30,7 @@
 		<None Include="..\..\documentation\articles\usageConnect.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="MASES.JNetCLICore" Version="2.6.9-rc93" />
+		<PackageReference Include="MASES.JNetCLICore" Version="2.6.9-rc94" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/net/KNetPS/KNetPS.csproj
+++ b/src/net/KNetPS/KNetPS.csproj
@@ -41,7 +41,7 @@
 			<!--<IncludeAssets>All</IncludeAssets>-->
 			<!--<PrivateAssets>None</PrivateAssets>-->
 		</ProjectReference>
-		<PackageReference Include="MASES.JNetPSCore" Version="2.6.9-rc93" />
+		<PackageReference Include="MASES.JNetPSCore" Version="2.6.9-rc94" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add deterministic disposal for temporary JVM/serialized objects to prevent leaks. Introduced using/try-finally blocks to dispose keys, values, headers and intermediate serialized results across ConsumerRecord, KNetProducer, Processor.Record, KStream mappers/joiners/initializers/reducers/aggregators, and read-only/timestamped window/session/key-value stores. Added OnApplyDispose constructors and protected DisposeResult helpers on several KStream delegates. Also added System imports where needed. These changes ensure IDisposable JVM bridge objects are released after use.

* Use Java wrappers and dispose Java objects

Wrap Java string/duration arguments with Java.Lang.String or Java.Time.Duration and add using/try-finally blocks to dispose JVM objects. Ensure serialized/deserialized values, IJavaObject instances and method arguments are properly disposed across KNet configuration and Streams/KStream/Kstream processor classes to prevent resource leaks; also add Java.Time using in KNetStreams.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
