### PR TITLE
Ensure JCOBridge thread detached in consumers

### DIFF
--- a/src/net/KNet/Specific/Consumer/KNetConsumer.cs
+++ b/src/net/KNet/Specific/Consumer/KNetConsumer.cs
@@ -297,6 +297,7 @@ namespace MASES.KNet.Consumer
                 }
             }
             catch { }
+            finally { JCOBridge.C2JBridge.JCOBridge.Global.LowLevelOperations.DetachThread(); }
         }
 #if NET7_0_OR_GREATER
         /// <inheritdoc cref="IConsumer{K, V, TJVMK, TJVMV}.IsPrefecth"/>

--- a/src/net/KNet/Specific/Consumer/KNetShareConsumer.cs
+++ b/src/net/KNet/Specific/Consumer/KNetShareConsumer.cs
@@ -284,6 +284,7 @@ namespace MASES.KNet.Consumer
                 }
             }
             catch { }
+            finally { JCOBridge.C2JBridge.JCOBridge.Global.LowLevelOperations.DetachThread(); }
         }
 #if NET7_0_OR_GREATER
         /// <inheritdoc cref="IShareConsumer{K, V, TJVMK, TJVMV}.IsPrefecth"/>

--- a/tests/net/General/KNetTest/Program.cs
+++ b/tests/net/General/KNetTest/Program.cs
@@ -532,7 +532,9 @@ namespace MASES.KNetTest
                                     lastOffset = item.Offset;
                                     if (!jumpWrotten && lastOffset != elements - 1)
                                     {
-                                        Console.WriteLine($"Lost message - expected offset {elements - 1} received {lastOffset} positionBeforePoll={positionBeforePoll} positionAfterPoll={positionAfterPoll}");
+                                        string strMsg = $"Lost message - expected offset {elements - 1} received {lastOffset} positionBeforePoll={positionBeforePoll} positionAfterPoll={positionAfterPoll}";
+                                        if (!avoidThrows) throw new InvalidOperationException(strMsg);
+                                        else Console.WriteLine(strMsg);
                                         jumpWrotten = true;
                                     }
                                     var key = item.Key;
@@ -547,11 +549,15 @@ namespace MASES.KNetTest
                             }
                             if (recordsCount != (positionAfterPoll - positionBeforePoll))
                             {
-                                Console.WriteLine($"Missing records - records.Count={recordsCount} positionBeforePoll={positionBeforePoll} positionAfterPoll={positionAfterPoll}");
+                                var strMsg = $"Missing records - records.Count={recordsCount} positionBeforePoll={positionBeforePoll} positionAfterPoll={positionAfterPoll}";
+                                if (!avoidThrows) throw new InvalidOperationException(strMsg);
+                                else Console.WriteLine(strMsg);
                             }
                             if (forEachIteration != recordsCount)
                             {
-                                Console.WriteLine($"BATCH TRUNCATED: declared={recordsCount} delivered={forEachIteration}");
+                                var strMsg = $"BATCH TRUNCATED: declared={recordsCount} delivered={forEachIteration}";
+                                if (!avoidThrows) throw new InvalidOperationException(strMsg);
+                                else Console.WriteLine(strMsg);
                             }
                             bool elapsedTimeout = !runInParallel && swCycleTime.ElapsedMilliseconds > waitTime;
                             bool tooManyEmptyCycles = elements != 0 && emptyCycle > maxEmptyCycle;
@@ -682,7 +688,7 @@ namespace MASES.KNetTest
                         int emptyCycle = 0;
                         long firstOffset = -1;
                         long lastOffset = -1;
-                        TopicPartition topicPartition = new TopicPartition(topicToUse, 0);
+                        Exception exceptionRaised = null;
 #if NET7_0_OR_GREATER
                         consumer.ApplyPrefetch(withPrefetch);
 #endif
@@ -693,7 +699,12 @@ namespace MASES.KNetTest
                             if (firstOffset == -1) firstOffset = record.Offset;
                             watcherTotal.Start();
                             lastOffset = record.Offset;
-                            if (lastOffset != elements - 1) Console.WriteLine($"Lost message - expected offset {elements - 1} received {lastOffset}");
+                            if (lastOffset != elements - 1)
+                            {
+                                var strMsg = $"Lost message - expected offset {elements - 1} received {lastOffset}";
+                                if (!avoidThrows) throw new InvalidOperationException(strMsg);
+                                else Console.WriteLine(strMsg);
+                            }
                             var key = record.Key;
                             var value = record.Value;
                             var str = $"Consuming from Offset = {lastOffset}, Key = {key}, Value = {value}";
@@ -702,17 +713,24 @@ namespace MASES.KNetTest
                             if (consoleOutput) Console.WriteLine(str);
                             watcher.Stop();
                             return true;
+                        }, (exception) =>
+                        {
+                            exceptionRaised = exception;
                         });
                         while (runInParallel ? !resetEvent.WaitOne(0) : elements < NonParallelLimit)
                         {
-                            var positionBeforePoll = consumer.Position(topicPartition);
                             consumeAsyncPrecision.Start();
                             if (!consumer.ConsumeAsync(checkTime))
                             {
                                 Interlocked.Increment(ref emptyCycle);
                             }
                             consumeAsyncPrecision.Stop();
-                            var positionAfterPoll = consumer.Position(topicPartition);
+                            if (exceptionRaised != null)
+                            {
+                                if (!avoidThrows) throw exceptionRaised;
+                                else Console.WriteLine(exceptionRaised);
+                                exceptionRaised = null;
+                            }
                             bool elapsedTimeout = !runInParallel && swCycleTime.ElapsedMilliseconds > waitTime;
                             bool tooManyEmptyCycles = elements != 0 && Volatile.Read(ref emptyCycle) > maxEmptyCycle;
                             if (elapsedTimeout // exit for elapsed timeout or
@@ -965,7 +983,9 @@ namespace MASES.KNetTest
                                     lastOffset = item.Offset;
                                     if (!jumpWrotten && lastOffset != elements - 1)
                                     {
-                                        Console.WriteLine($"Lost message - expected offset {elements - 1} received {lastOffset} positionBeforePoll={positionBeforePoll} positionAfterPoll={positionAfterPoll}");
+                                        var strMsg = $"Lost message - expected offset {elements - 1} received {lastOffset} positionBeforePoll={positionBeforePoll} positionAfterPoll={positionAfterPoll}";
+                                        if (!avoidThrows) throw new InvalidOperationException(strMsg);
+                                        else Console.WriteLine(strMsg);
                                         jumpWrotten = true;
                                     }
                                     var key = item.Key;
@@ -980,11 +1000,15 @@ namespace MASES.KNetTest
                             }
                             if (recordsCount != (positionAfterPoll - positionBeforePoll))
                             {
-                                Console.WriteLine($"Missing records - records.Count={recordsCount} positionBeforePoll={positionBeforePoll} positionAfterPoll={positionAfterPoll}");
+                                var strMsg = $"Missing records - records.Count={recordsCount} positionBeforePoll={positionBeforePoll} positionAfterPoll={positionAfterPoll}";
+                                if (!avoidThrows) throw new InvalidOperationException(strMsg);
+                                else Console.WriteLine(strMsg);
                             }
                             if (forEachIteration != recordsCount)
                             {
-                                Console.WriteLine($"BATCH TRUNCATED: declared={recordsCount} delivered={forEachIteration}");
+                                var strMsg = $"BATCH TRUNCATED: declared={recordsCount} delivered={forEachIteration}";
+                                if (!avoidThrows) throw new InvalidOperationException(strMsg);
+                                else Console.WriteLine(strMsg);
                             }
                             bool elapsedTimeout = !runInParallel && swCycleTime.ElapsedMilliseconds > waitTime;
                             bool tooManyEmptyCycles = elements != 0 && emptyCycle > maxEmptyCycle;
@@ -1113,6 +1137,7 @@ namespace MASES.KNetTest
                         int emptyCycle = 0;
                         long firstOffset = -1;
                         long lastOffset = -1;
+                        Exception exceptionRaised = null;
 #if NET7_0_OR_GREATER
                         consumer.ApplyPrefetch(withPrefetch);
 #endif
@@ -1123,7 +1148,12 @@ namespace MASES.KNetTest
                             if (firstOffset == -1) firstOffset = record.Offset;
                             watcherTotal.Start();
                             lastOffset = record.Offset;
-                            if (lastOffset != elements - 1) Console.WriteLine($"Lost message - expected offset {elements - 1} received {lastOffset}");
+                            if (lastOffset != elements - 1)
+                            {
+                                var strMsg = $"Lost message - expected offset {elements - 1} received {lastOffset}";
+                                if (!avoidThrows) throw new InvalidOperationException(strMsg);
+                                else Console.WriteLine(strMsg);
+                            }
                             var key = record.Key;
                             var value = record.Value;
                             var str = $"Consuming from Offset = {lastOffset}, Key = {key}, Value = {value}";
@@ -1132,6 +1162,9 @@ namespace MASES.KNetTest
                             if (consoleOutput) Console.WriteLine(str);
                             watcher.Stop();
                             return true;
+                        }, (exception) =>
+                        {
+                            exceptionRaised = exception;
                         });
                         while (runInParallel ? !resetEvent.WaitOne(0) : elements < NonParallelLimit)
                         {
@@ -1141,6 +1174,12 @@ namespace MASES.KNetTest
                                 Interlocked.Increment(ref emptyCycle);
                             }
                             consumeAsyncPrecision.Stop();
+                            if (exceptionRaised != null)
+                            {
+                                if (!avoidThrows) throw exceptionRaised;
+                                else Console.WriteLine(exceptionRaised);
+                                exceptionRaised = null;
+                            }
                             bool elapsedTimeout = !runInParallel && swCycleTime.ElapsedMilliseconds > waitTime;
                             bool tooManyEmptyCycles = elements != 0 && Volatile.Read(ref emptyCycle) > maxEmptyCycle;
                             if (elapsedTimeout // exit for elapsed timeout or


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a finally block to call JCOBridge.C2JBridge.JCOBridge.Global.LowLevelOperations.DetachThread() in KNetConsumer and KNetShareConsumer. This ensures the underlying JCOBridge thread is detached even when exceptions occur, preventing potential resource/thread state leaks during consumer shutdown or error paths.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
