### PR TITLE
Null out inner fields in Dispose to free resources

### DIFF
--- a/src/net/KNet/Developed/Org/Apache/Kafka/Streams/Kstream/ValueTransformerWithKeySupplier.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Streams/Kstream/ValueTransformerWithKeySupplier.cs
@@ -50,6 +50,13 @@ namespace Org.Apache.Kafka.Streams.Kstream
         public ValueTransformerWithKeySupplier() { InitializeHandlers(); }
 
         /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            m_list.Clear();
+            base.Dispose(disposing);
+        }
+
+        /// <inheritdoc/>
         public override string BridgeClassName => "org.mases.knet.developed.streams.kstream.ValueTransformerWithKeySupplier";
         #endregion
 

--- a/src/net/KNet/Developed/Org/Apache/Kafka/Streams/Processor/Api/FixedKeyProcessorSupplier.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Streams/Processor/Api/FixedKeyProcessorSupplier.cs
@@ -91,6 +91,13 @@ namespace Org.Apache.Kafka.Streams.Processor.Api
         /// </summary>
         public FixedKeyProcessorSupplier() { InitializeHandlers(); }
 
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            m_list.Clear();
+            base.Dispose(disposing);
+        }
+
         #endregion
 
         #region Instance methods

--- a/src/net/KNet/Developed/Org/Apache/Kafka/Streams/Processor/Api/ProcessorSupplier.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Streams/Processor/Api/ProcessorSupplier.cs
@@ -89,6 +89,13 @@ namespace Org.Apache.Kafka.Streams.Processor.Api
         public ProcessorSupplier() { InitializeHandlers(); }
 
         /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            m_list.Clear();
+            base.Dispose(disposing);
+        }
+
+        /// <inheritdoc/>
         public override string BridgeClassName => "org.mases.knet.developed.streams.processor.api.ProcessorSupplier";
         #endregion
 

--- a/src/net/KNet/Specific/Consumer/ConsumerRecord.cs
+++ b/src/net/KNet/Specific/Consumer/ConsumerRecord.cs
@@ -33,7 +33,7 @@ namespace MASES.KNet.Consumer
     {
         IDeserializer<K, TJVMK> _keyDeserializer;
         IDeserializer<V, TJVMV> _valueDeserializer;
-        readonly Org.Apache.Kafka.Clients.Consumer.ConsumerRecord<TJVMK, TJVMV> _record;
+        Org.Apache.Kafka.Clients.Consumer.ConsumerRecord<TJVMK, TJVMV> _record;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         /// <summary>
@@ -95,6 +95,19 @@ namespace MASES.KNet.Consumer
             if (disposing)
             {
                 _record?.Dispose();
+                _record = null;
+                _headers = null;
+                _topic = null;
+                _partition = null;
+                _offset = null;
+                _timestamp = null;
+                _timestampType = null;
+                _serializedKeySize = null;
+                _serializedValueSize = null;
+                _localKeyDes = false;
+                _localKey = default;
+                _localValueDes = false;
+                _localValue = default;
             }
         }
 

--- a/src/net/KNet/Specific/Consumer/ConsumerRecords.cs
+++ b/src/net/KNet/Specific/Consumer/ConsumerRecords.cs
@@ -33,9 +33,9 @@ namespace MASES.KNet.Consumer
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public class ConsumerRecords<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Clients.Consumer.ConsumerRecords<TJVMK, TJVMV>>, IEnumerable<ConsumerRecord<K, V, TJVMK, TJVMV>>, IAsyncEnumerable<ConsumerRecord<K, V, TJVMK, TJVMV>>, IDisposable
     {
-        readonly ISerDes<K, TJVMK> _keyDeserializer;
-        readonly ISerDes<V, TJVMV> _valueDeserializer;
-        readonly Org.Apache.Kafka.Clients.Consumer.ConsumerRecords<TJVMK, TJVMV> _records;
+        ISerDes<K, TJVMK> _keyDeserializer;
+        ISerDes<V, TJVMV> _valueDeserializer;
+        Org.Apache.Kafka.Clients.Consumer.ConsumerRecords<TJVMK, TJVMV> _records;
         /// <summary>
         /// Initialize a new <see cref="ConsumerRecord{K, V, TJVMK, TJVMV}"/>
         /// </summary>
@@ -79,6 +79,9 @@ namespace MASES.KNet.Consumer
             if (disposing)
             {
                 _records?.Dispose();
+                _records = null;
+                _keyDeserializer = null;
+                _valueDeserializer = null;
             }
         }
 

--- a/src/net/KNet/Specific/Consumer/ConsumerRecordsEnumerator.cs
+++ b/src/net/KNet/Specific/Consumer/ConsumerRecordsEnumerator.cs
@@ -26,10 +26,10 @@ namespace MASES.KNet.Consumer
 {
     class ConsumerRecordsEnumerator<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Clients.Consumer.ConsumerRecords<TJVMK, TJVMV>>, IEnumerator<ConsumerRecord<K, V, TJVMK, TJVMV>>, IAsyncEnumerator<ConsumerRecord<K, V, TJVMK, TJVMV>>
     {
-        readonly IDeserializer<K, TJVMK> _keyDeserializer;
-        readonly IDeserializer<V, TJVMV> _valueDeserializer;
-        readonly CancellationToken _cancellationToken;
-        readonly Org.Apache.Kafka.Clients.Consumer.ConsumerRecords<TJVMK, TJVMV> _records;
+        IDeserializer<K, TJVMK> _keyDeserializer;
+        IDeserializer<V, TJVMV> _valueDeserializer;
+        CancellationToken _cancellationToken;
+        Org.Apache.Kafka.Clients.Consumer.ConsumerRecords<TJVMK, TJVMV> _records;
         IEnumerator<Org.Apache.Kafka.Clients.Consumer.ConsumerRecord<TJVMK, TJVMV>> _recordEnumerator;
         IAsyncEnumerator<Org.Apache.Kafka.Clients.Consumer.ConsumerRecord<TJVMK, TJVMV>> _recordAsyncEnumerator;
 
@@ -87,6 +87,9 @@ namespace MASES.KNet.Consumer
             {
                 _recordEnumerator?.Dispose();
                 _recordAsyncEnumerator?.DisposeAsync();
+                _records = null;
+                _keyDeserializer = null;
+                _valueDeserializer = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/KNetStreams.cs
+++ b/src/net/KNet/Specific/Streams/KNetStreams.cs
@@ -30,9 +30,9 @@ namespace MASES.KNet.Streams
     /// </summary>
     public class KNetStreams : IKNetInnerReference<Org.Apache.Kafka.Streams.KafkaStreams>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Java.Util.Properties _properties;
-        readonly Org.Apache.Kafka.Streams.KafkaStreams _inner;
-        readonly KNetClientSupplier _supplier = null; // used to avoid GC recall
+        Java.Util.Properties _properties;
+        Org.Apache.Kafka.Streams.KafkaStreams _inner;
+        KNetClientSupplier _supplier = null; // used to avoid GC recall
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 
@@ -126,7 +126,10 @@ namespace MASES.KNet.Streams
             if (disposing)
             {
                 _properties?.Dispose();
+                _properties = null;
                 _inner?.Dispose();
+                _inner = null;
+                _supplier = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/KeyValue.cs
+++ b/src/net/KNet/Specific/Streams/KeyValue.cs
@@ -31,7 +31,7 @@ namespace MASES.KNet.Streams
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public sealed class KeyValue<K, V, TJVMK, TJVMV> : IKNetInnerReference<KeyValueSupport<TJVMK, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly KeyValueSupport<TJVMK, TJVMV> _inner = null;
+        KeyValueSupport<TJVMK, TJVMV> _inner = null;
         K _key;
         bool _keyStored;
         V _value;
@@ -98,6 +98,11 @@ namespace MASES.KNet.Streams
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
+                _key = default;
+                _keyStored = false;
+                _value = default;
+                _valueStored = true;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/KeyValueSupport.cs
+++ b/src/net/KNet/Specific/Streams/KeyValueSupport.cs
@@ -29,7 +29,7 @@ namespace MASES.KNet.Streams
     /// </summary>
     public partial class KeyValueSupport<K, V> : MASES.JCOBridge.C2JBridge.JVMBridgeBase<KeyValueSupport<K, V>>
     {
-        readonly IJavaObject _inner;
+        IJavaObject _inner;
 
         #region Constructors
         /// <summary>
@@ -111,6 +111,7 @@ namespace MASES.KNet.Streams
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
 
             base.Dispose(disposing);

--- a/src/net/KNet/Specific/Streams/Kstream/Branched.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Branched.cs
@@ -33,7 +33,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public class Branched<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.Branched<TJVMK, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.Branched<TJVMK, TJVMV> _inner;
+        Org.Apache.Kafka.Streams.Kstream.Branched<TJVMK, TJVMV> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/CogroupedKStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/CogroupedKStream.cs
@@ -75,6 +75,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/Consumed.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Consumed.cs
@@ -37,7 +37,7 @@ namespace MASES.KNet.Streams.Kstream
         ISerDes<V, TJVMV> _valueSerdes;
 
         TimestampExtractor<K, V, TJVMK, TJVMV> _timestampExtractor = null;
-        readonly Org.Apache.Kafka.Streams.Kstream.Consumed<TJVMK, TJVMV> _inner;
+        Org.Apache.Kafka.Streams.Kstream.Consumed<TJVMK, TJVMV> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory
         {
@@ -86,6 +86,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/GlobalKTable.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/GlobalKTable.cs
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/Grouped.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Grouped.cs
@@ -32,7 +32,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMV">The JVM value type</typeparam>
     public class Grouped<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.Grouped<TJVMK, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.Grouped<TJVMK, TJVMV> _inner;
+        Org.Apache.Kafka.Streams.Kstream.Grouped<TJVMK, TJVMV> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 
@@ -73,6 +73,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/Joined.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Joined.cs
@@ -33,7 +33,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMVO">The JVM type of <typeparamref name="VO"/></typeparam>
     public class Joined<K, V, VO, TJVMK, TJVMV, TJVMVO> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.Joined<TJVMK, TJVMV, TJVMVO>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.Joined<TJVMK, TJVMV, TJVMVO> _inner;
+        Org.Apache.Kafka.Streams.Kstream.Joined<TJVMK, TJVMV, TJVMVO> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/KBranchedKStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KBranchedKStream.cs
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/KGroupedStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KGroupedStream.cs
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/KGroupedTable.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KGroupedTable.cs
@@ -71,11 +71,12 @@ namespace MASES.KNet.Streams.Kstream
 			if (Interlocked.Exchange(ref _disposed, 1) != 0)
 				return;
 
-            if (disposing)
-            {
-                _inner?.Dispose();
+			if (disposing)
+			{
+				_inner?.Dispose();
+                _inner = null;
             }
-        }
+		}
 
         #endregion
 

--- a/src/net/KNet/Specific/Streams/Kstream/KStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KStream.cs
@@ -75,6 +75,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/KTable.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KTable.cs
@@ -32,7 +32,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public class KTable<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.KTable<TJVMK, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.KTable<TJVMK, TJVMV> _inner;
+        Org.Apache.Kafka.Streams.Kstream.KTable<TJVMK, TJVMV> _inner;
 
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
@@ -75,6 +75,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/Printed.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Printed.cs
@@ -31,7 +31,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public class Printed<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.Printed<TJVMK, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.Printed<TJVMK, TJVMV> _inner;
+        Org.Apache.Kafka.Streams.Kstream.Printed<TJVMK, TJVMV> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 
@@ -72,6 +72,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/Produced.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Produced.cs
@@ -33,7 +33,7 @@ namespace MASES.KNet.Streams.Kstream
     public class Produced<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.Produced<TJVMK, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
         StreamPartitioner<K, V, TJVMK, TJVMV> _streamPartitioner = null;
-        readonly Org.Apache.Kafka.Streams.Kstream.Produced<TJVMK, TJVMV> _inner;
+        Org.Apache.Kafka.Streams.Kstream.Produced<TJVMK, TJVMV> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory
         {
@@ -83,6 +83,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/Repartitioned.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Repartitioned.cs
@@ -34,7 +34,7 @@ namespace MASES.KNet.Streams.Kstream
     public class Repartitioned<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.Repartitioned<TJVMK, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
         StreamPartitioner<K, V, TJVMK, TJVMV> _streamPartitioner = null;
-        readonly Org.Apache.Kafka.Streams.Kstream.Repartitioned<TJVMK, TJVMV> _inner;
+        Org.Apache.Kafka.Streams.Kstream.Repartitioned<TJVMK, TJVMV> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory
         {
@@ -84,6 +84,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/SessionWindowedCogroupedKStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/SessionWindowedCogroupedKStream.cs
@@ -31,7 +31,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public class SessionWindowedCogroupedKStream<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.SessionWindowedCogroupedKStream<TJVMK, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.SessionWindowedCogroupedKStream<TJVMK, TJVMV> _inner;
+        Org.Apache.Kafka.Streams.Kstream.SessionWindowedCogroupedKStream<TJVMK, TJVMV> _inner;
 
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
@@ -73,7 +73,8 @@ namespace MASES.KNet.Streams.Kstream
 
             if (disposing)
             {
-                _inner?.Dispose();
+                _inner?.Dispose(); 
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/SessionWindowedKStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/SessionWindowedKStream.cs
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/StreamJoined.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/StreamJoined.cs
@@ -33,7 +33,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMV2">The JVM type of <typeparamref name="V2"/></typeparam>
     public class StreamJoined<K, V1, V2, TJVMK, TJVMV1, TJVMV2> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.StreamJoined<TJVMK, TJVMV1, TJVMV2>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.StreamJoined<TJVMK, TJVMV1, TJVMV2> _inner;
+        Org.Apache.Kafka.Streams.Kstream.StreamJoined<TJVMK, TJVMV1, TJVMV2> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/Suppressed.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Suppressed.cs
@@ -29,7 +29,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMK">The JVM type of <typeparamref name="K"/></typeparam>
     public class Suppressed<K, TJVMK> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.Suppressed<TJVMK>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.Suppressed<TJVMK> _inner;
+        Org.Apache.Kafka.Streams.Kstream.Suppressed<TJVMK> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 
@@ -70,6 +70,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/TableJoined.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/TableJoined.cs
@@ -32,7 +32,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMKO">The JVM type of <typeparamref name="KO"/></typeparam>
     public class TableJoined<K, KO, TJVMK, TJVMKO> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.TableJoined<TJVMK, TJVMKO>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.TableJoined<TJVMK, TJVMKO> _inner;
+        Org.Apache.Kafka.Streams.Kstream.TableJoined<TJVMK, TJVMKO> _inner;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 
@@ -73,6 +73,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/TimeWindowedCogroupedKStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/TimeWindowedCogroupedKStream.cs
@@ -31,7 +31,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public class TimeWindowedCogroupedKStream<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.TimeWindowedCogroupedKStream<TJVMK, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.TimeWindowedCogroupedKStream<TJVMK, TJVMV> _inner;
+        Org.Apache.Kafka.Streams.Kstream.TimeWindowedCogroupedKStream<TJVMK, TJVMV> _inner;
 
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/TimeWindowedKStream.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/TimeWindowedKStream.cs
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Kstream/Windowed.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Windowed.cs
@@ -29,7 +29,7 @@ namespace MASES.KNet.Streams.Kstream
     /// <typeparam name="TJVMK">The JVM type of <typeparamref name="K"/></typeparam>
     public class Windowed<K, TJVMK> : IKNetInnerReference<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK> _inner;
+        Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK> _inner;
         ISerDes<K, TJVMK> _keySerDes = null;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
@@ -72,6 +72,7 @@ namespace MASES.KNet.Streams.Kstream
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Processor/Api/ProcessorContext.cs
+++ b/src/net/KNet/Specific/Streams/Processor/Api/ProcessorContext.cs
@@ -31,7 +31,7 @@ namespace MASES.KNet.Streams.Processor.Api
 	/// <typeparam name="TJVMVForward">The JVM type of <typeparamref name="VForward"/></typeparam>
 	public class ProcessorContext<KForward, VForward, TJVMKForward, TJVMVForward> : IKNetInnerReference<Org.Apache.Kafka.Streams.Processor.Api.ProcessorContext<TJVMKForward, TJVMVForward>>, IDisposable
 	{
-		readonly Org.Apache.Kafka.Streams.Processor.Api.ProcessorContext<TJVMKForward, TJVMVForward> _context;
+		Org.Apache.Kafka.Streams.Processor.Api.ProcessorContext<TJVMKForward, TJVMVForward> _context;
 
 		internal ProcessorContext(Org.Apache.Kafka.Streams.Processor.Api.ProcessorContext<TJVMKForward, TJVMVForward> context)
 		{
@@ -67,11 +67,12 @@ namespace MASES.KNet.Streams.Processor.Api
 			if (Interlocked.Exchange(ref _disposed, 1) != 0)
 				return;
 
-            if (disposing)
-            {
-                _context?.Dispose();
-            }
-        }
+			if (disposing)
+			{
+				_context?.Dispose();
+				_context = null;
+			}
+		}
 
         #endregion
 

--- a/src/net/KNet/Specific/Streams/Processor/Api/Record.cs
+++ b/src/net/KNet/Specific/Streams/Processor/Api/Record.cs
@@ -33,8 +33,8 @@ namespace MASES.KNet.Streams.Processor.Api
     public class Record<K, V, TJVMK, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.Processor.Api.Record<TJVMK, TJVMV>>, IDisposable
     {
         readonly IGenericSerDesFactory _builder;
-        readonly Org.Apache.Kafka.Streams.Processor.Api.Record<TJVMK, TJVMV> _record;
-        readonly Org.Apache.Kafka.Streams.Processor.Api.RecordMetadata _metadata;
+        Org.Apache.Kafka.Streams.Processor.Api.Record<TJVMK, TJVMV> _record;
+        Org.Apache.Kafka.Streams.Processor.Api.RecordMetadata _metadata;
 
         internal Record(IGenericSerDesFactory builder, Org.Apache.Kafka.Streams.Processor.Api.Record<TJVMK, TJVMV> record, Org.Apache.Kafka.Streams.Processor.Api.RecordMetadata metadata)
         {
@@ -75,7 +75,9 @@ namespace MASES.KNet.Streams.Processor.Api
             if (disposing)
             {
                 _record?.Dispose();
+                _record = null;
                 _metadata?.Dispose();
+                _metadata = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/State/KeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/KeyValueIterator.cs
@@ -123,7 +123,7 @@ namespace MASES.KNet.Streams.State
             }
         }
 
-        readonly Org.Apache.Kafka.Streams.State.KeyValueIterator<TJVMK, TJVMV> _iterator;
+        Org.Apache.Kafka.Streams.State.KeyValueIterator<TJVMK, TJVMV> _iterator;
         ISerDes<K, TJVMK> _keySerDes = null;
         ISerDes<V, TJVMV> _valueSerDes = null;
 
@@ -140,6 +140,7 @@ namespace MASES.KNet.Streams.State
         protected override void Dispose(bool disposing)
         {
             _iterator?.Dispose();
+            _iterator = null;
             base.Dispose(disposing);
         }
 

--- a/src/net/KNet/Specific/Streams/State/TimestampedKeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/TimestampedKeyValueIterator.cs
@@ -116,7 +116,7 @@ namespace MASES.KNet.Streams.State
             }
         }
 
-        readonly Org.Apache.Kafka.Streams.State.KeyValueIterator<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _iterator = null;
+        Org.Apache.Kafka.Streams.State.KeyValueIterator<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _iterator = null;
         ISerDes<K, TJVMK> _keySerDes;
 
         internal TimestampedKeyValueIterator(IGenericSerDesFactory factory, Org.Apache.Kafka.Streams.State.KeyValueIterator<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> iterator)
@@ -132,6 +132,7 @@ namespace MASES.KNet.Streams.State
         protected override void Dispose(bool disposing)
         {
             _iterator?.Dispose();
+            _iterator = null;
             base.Dispose(disposing);
         }
 

--- a/src/net/KNet/Specific/Streams/State/TimestampedWindowStoreIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/TimestampedWindowStoreIterator.cs
@@ -28,7 +28,7 @@ namespace MASES.KNet.Streams.State
     /// <typeparam name="TJVMV">The JVM value type</typeparam>
     public sealed class TimestampedWindowStoreIterator<V, TJVMV> : IGenericSerDesFactoryApplier
     {
-        readonly Org.Apache.Kafka.Streams.State.WindowStoreIterator<Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _iterator;
+        Org.Apache.Kafka.Streams.State.WindowStoreIterator<Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _iterator;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 

--- a/src/net/KNet/Specific/Streams/State/TimestampedWindowedKeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/TimestampedWindowedKeyValueIterator.cs
@@ -109,7 +109,7 @@ namespace MASES.KNet.Streams.State
             }
         }
 
-        readonly Org.Apache.Kafka.Streams.State.KeyValueIterator<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _iterator;
+        Org.Apache.Kafka.Streams.State.KeyValueIterator<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _iterator;
 
         internal TimestampedWindowedKeyValueIterator(IGenericSerDesFactory factory, Org.Apache.Kafka.Streams.State.KeyValueIterator<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> iterator)
             : base(factory)
@@ -124,6 +124,7 @@ namespace MASES.KNet.Streams.State
         protected override void Dispose(bool disposing)
         {
             _iterator?.Dispose();
+            _iterator = null;
             base.Dispose(disposing);
         }
 

--- a/src/net/KNet/Specific/Streams/State/ValueAndTimestamp.cs
+++ b/src/net/KNet/Specific/Streams/State/ValueAndTimestamp.cs
@@ -31,7 +31,7 @@ namespace MASES.KNet.Streams.State
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public class ValueAndTimestamp<V, TJVMV> : IKNetInnerReference<Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV> _inner;
+        Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV> _inner;
         ISerDes<V, TJVMV> _valueSerDes;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
@@ -74,6 +74,7 @@ namespace MASES.KNet.Streams.State
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/State/WindowStoreIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/WindowStoreIterator.cs
@@ -28,7 +28,7 @@ namespace MASES.KNet.Streams.State
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public class WindowStoreIterator<V, TJVMV> : IGenericSerDesFactoryApplier
     { 
-        readonly Org.Apache.Kafka.Streams.State.WindowStoreIterator<TJVMV> _iterator;
+        Org.Apache.Kafka.Streams.State.WindowStoreIterator<TJVMV> _iterator;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
 

--- a/src/net/KNet/Specific/Streams/State/WindowedKeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/WindowedKeyValueIterator.cs
@@ -118,7 +118,7 @@ namespace MASES.KNet.Streams.State
             }
         }
 
-        readonly Org.Apache.Kafka.Streams.State.KeyValueIterator<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV> _iterator;
+        Org.Apache.Kafka.Streams.State.KeyValueIterator<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV> _iterator;
         ISerDes<V, TJVMV> _valueSerDes = null;
 
         internal WindowedKeyValueIterator(IGenericSerDesFactory factory, Org.Apache.Kafka.Streams.State.KeyValueIterator<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV> iterator)
@@ -134,6 +134,7 @@ namespace MASES.KNet.Streams.State
         protected override void Dispose(bool disposing)
         {
             _iterator?.Dispose();
+            _iterator = null;
             base.Dispose(disposing);
         }
 

--- a/src/net/KNet/Specific/Streams/StreamsBuilder.cs
+++ b/src/net/KNet/Specific/Streams/StreamsBuilder.cs
@@ -87,6 +87,7 @@ namespace MASES.KNet.Streams
             if (disposing)
             {
                 _builder?.Dispose();
+                _builder = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/TimestampedKeyValue.cs
+++ b/src/net/KNet/Specific/Streams/TimestampedKeyValue.cs
@@ -34,7 +34,7 @@ namespace MASES.KNet.Streams
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public sealed class TimestampedKeyValue<K, V, TJVMK, TJVMV> : IKNetInnerReference<KeyValueSupport<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly KeyValueSupport<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _inner = null;
+        KeyValueSupport<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _inner = null;
 
         K _key;
         bool _keyStored = false;
@@ -91,6 +91,11 @@ namespace MASES.KNet.Streams
             if (disposing)
             {
                 _inner?.Dispose();
+                _inner = null;
+                _key = default;
+                _keyStored = false;
+                _value = null;
+                _keySerDes = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/TimestampedWindowedKeyValue.cs
+++ b/src/net/KNet/Specific/Streams/TimestampedWindowedKeyValue.cs
@@ -34,7 +34,7 @@ namespace MASES.KNet.Streams
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public sealed class TimestampedWindowedKeyValue<K, V, TJVMK, TJVMV> : IKNetInnerReference<KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _valueInner;
+        KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>> _valueInner;
         Windowed<K, TJVMK> _key = null;
         ValueAndTimestamp<V, TJVMV> _value = null;
         IGenericSerDesFactory _factory;
@@ -77,6 +77,9 @@ namespace MASES.KNet.Streams
             if (disposing)
             {
                 _valueInner?.Dispose();
+                _valueInner = default;
+                _key = null;
+                _value = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/Topology.cs
+++ b/src/net/KNet/Specific/Streams/Topology.cs
@@ -31,7 +31,7 @@ namespace MASES.KNet.Streams
     /// </summary>
     public class Topology : IKNetInnerReference<Org.Apache.Kafka.Streams.Topology>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly Org.Apache.Kafka.Streams.Topology _topology;
+        Org.Apache.Kafka.Streams.Topology _topology;
         IGenericSerDesFactory _factory;
         IGenericSerDesFactory IGenericSerDesFactoryApplier.Factory { get => _factory; set => _factory = value; }
         #region Constructors
@@ -87,6 +87,7 @@ namespace MASES.KNet.Streams
             if (disposing)
             {
                 _topology?.Dispose();
+                _topology = null;
             }
         }
 

--- a/src/net/KNet/Specific/Streams/WindowedKeyValue.cs
+++ b/src/net/KNet/Specific/Streams/WindowedKeyValue.cs
@@ -34,7 +34,7 @@ namespace MASES.KNet.Streams
     /// <typeparam name="TJVMV">The JVM type of <typeparamref name="V"/></typeparam>
     public sealed class WindowedKeyValue<K, V, TJVMK, TJVMV> : IKNetInnerReference<KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV>>, IGenericSerDesFactoryApplier, IDisposable
     {
-        readonly KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV> _valueInner;
+        KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV> _valueInner;
         Windowed<K, TJVMK> _key = null;
         V _value;
         bool _valueStored;
@@ -88,6 +88,11 @@ namespace MASES.KNet.Streams
             if (disposing)
             {
                 _valueInner?.Dispose();
+                _valueInner = null;
+                _key = null;
+                _value = default;
+                _valueStored = false;
+                _valueSerDes = null;
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Clear internal references during disposal to help GC and avoid leaks. Added Dispose overrides (clearing m_list) and null assignments for many wrapper fields, and removed readonly modifiers where necessary to allow nulling. Changes touch KNet Developed suppliers (ValueTransformerWithKeySupplier, FixedKeyProcessorSupplier, ProcessorSupplier), consumer types (ConsumerRecord(s), ConsumerRecordsEnumerator), Streams/Kstream wrappers (many _inner fields), state iterators, KeyValue/KeyValueSupport variants, and related classes to release underlying JVM objects and reset cached locals.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
