### PR TITLE
Introduce CastDirectAndDetach and migrate casts

### DIFF
--- a/src/net/KNet/Specific/Connect/KNetConnectExtensions.cs
+++ b/src/net/KNet/Specific/Connect/KNetConnectExtensions.cs
@@ -78,5 +78,23 @@ namespace MASES.KNet.Connect
         {
             return source.Select((o) => o.CastTo<SinkRecord<TKey, TValue>>());
         }
+        /// <summary>
+        /// Converts an <see cref="IEnumerable{SinkRecord}"/> in <see cref="IEnumerable{T}"/> of <see cref="SinkRecord{Object, TValue}"/>
+        /// </summary>
+        /// <param name="source">The <see cref="IEnumerable{SinkRecord}"/> to convert</param>
+        /// <remarks><paramref name="source"/> cannot be used after <see cref="CastDirectAndDetach{TValue}(IEnumerable{SinkRecord})"/> is invoked</remarks>
+        public static IEnumerable<SinkRecord<object, TValue>> CastDirectAndDetach<TValue>(this IEnumerable<SinkRecord> source)
+        {
+            return source.Select((o) => o.CastDirectAndDetach<SinkRecord<object, TValue>>());
+        }
+        /// <summary>
+        /// Converts an <see cref="IEnumerable{SinkRecord}"/> in <see cref="IEnumerable{T}"/> of <see cref="SinkRecord{TKey, TValue}"/>
+        /// </summary>
+        /// <param name="source">The <see cref="IEnumerable{SinkRecord}"/> to convert</param>
+        /// <remarks><paramref name="source"/> cannot be used after <see cref="CastDirectAndDetach{TKey, TValue}(IEnumerable{SinkRecord})"/> is invoked</remarks>
+        public static IEnumerable<SinkRecord<TKey, TValue>> CastDirectAndDetach<TKey, TValue>(this IEnumerable<SinkRecord> source)
+        {
+            return source.Select((o) => o.CastDirectAndDetach<SinkRecord<TKey, TValue>>());
+        }
     }
 }

--- a/src/net/KNet/Specific/Connect/Transforms/KNetTransformation.cs
+++ b/src/net/KNet/Specific/Connect/Transforms/KNetTransformation.cs
@@ -119,11 +119,11 @@ namespace MASES.KNet.Connect.Transforms
 
             if (record.IsInstanceOf<SourceRecord>())
             {
-                return Apply(record.CastTo<SourceRecord>());
+                return Apply(record.CastDirectAndDetach<SourceRecord>());
             }
             else if (record.IsInstanceOf<SinkRecord>())
             {
-                return Apply(record.CastTo<SinkRecord>());
+                return Apply(record.CastDirectAndDetach<SinkRecord>());
             }
             else JVMBridgeException.Throw<ConnectException>($"Cannot manage directly the input, override the method {nameof(Apply)} with generic {nameof(ConnectRecord)} parameter.");
             return null;

--- a/src/net/KNet/Specific/Connect/Transforms/Predicates/KNetPredicate.cs
+++ b/src/net/KNet/Specific/Connect/Transforms/Predicates/KNetPredicate.cs
@@ -122,11 +122,11 @@ namespace MASES.KNet.Connect.Transforms.Predicates
 
             if (record.IsInstanceOf<SourceRecord>())
             {
-                return Test(record.CastTo<SourceRecord>());
+                return Test(record.CastDirectAndDetach<SourceRecord>());
             }
             else if (record.IsInstanceOf<SinkRecord>())
             {
-                return Test(record.CastTo<SinkRecord>());
+                return Test(record.CastDirectAndDetach<SinkRecord>());
             }
             else JVMBridgeException.Throw<ConnectException>($"Cannot manage directly the input, override the method {nameof(Test)} with generic {nameof(ConnectRecord)} parameter.");
             return false;

--- a/src/net/KNet/Specific/Serialization/SerDes.cs
+++ b/src/net/KNet/Specific/Serialization/SerDes.cs
@@ -206,7 +206,7 @@ namespace MASES.KNet.Serialization
 
             if (IsDirectBuffered)
             {
-                kSerde = new Serdes.ByteBufferSerde().CastTo<SerdeDirect<TJVMT>>();
+                kSerde = new Serdes.ByteBufferSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                 JVMSerDesClassName = Class.ClassNameOf<MASES.KNet.Serialization.Serdes.ByteBufferSerde>();
                 JVMSerializerClassName = Class.ClassNameOf<MASES.KNet.Serialization.ByteBufferSerializer>();
                 JVMDeserializerClassName = Class.ClassNameOf<MASES.KNet.Serialization.ByteBufferDeserializer>();
@@ -216,73 +216,73 @@ namespace MASES.KNet.Serialization
                 switch (_JVMSerializationType)
                 {
                     case KNetSerialization.SerializationType.Boolean:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.BooleanSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.BooleanSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.BooleanSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.BooleanSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.BooleanDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.ByteArray:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.ByteArraySerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.ByteArraySerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.ByteArraySerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.ByteArraySerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.ByteArrayDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.ByteBuffer:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.ByteBufferSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.ByteBufferSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.ByteBufferSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.ByteBufferSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.ByteBufferDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.Bytes:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.BytesSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.BytesSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.BytesSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.BytesSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.BytesDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.Double:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.DoubleSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.DoubleSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.DoubleSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.DoubleSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.DoubleDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.Float:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.FloatSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.FloatSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.FloatSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.FloatSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.FloatDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.Integer:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.IntegerSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.IntegerSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.IntegerSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.IntegerSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.IntegerDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.Long:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.LongSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.LongSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.LongSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.LongSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.LongDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.Short:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.ShortSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.ShortSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.ShortSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.ShortSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.ShortDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.String:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.StringSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.StringSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.StringSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.StringSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.StringDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.Guid:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.UUIDSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.UUIDSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.UUIDSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.UUIDSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.UUIDDeserializer>();
                         break;
                     case KNetSerialization.SerializationType.Void:
-                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.VoidSerde().CastTo<SerdeDirect<TJVMT>>();
+                        kSerde = new Org.Apache.Kafka.Common.Serialization.Serdes.VoidSerde().CastDirectAndDetach<SerdeDirect<TJVMT>>();
                         JVMSerDesClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.Serdes.VoidSerde>();
                         JVMSerializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.VoidSerializer>();
                         JVMDeserializerClassName = Class.ClassNameOf<Org.Apache.Kafka.Common.Serialization.VoidDeserializer>();

--- a/src/net/KNet/Specific/Streams/Kstream/Materialized.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/Materialized.cs
@@ -42,7 +42,7 @@ namespace MASES.KNet.Streams.Kstream
             CountingMaterialized<K, TJVMK> cont = new();
             if (cont is IKNetMaterialized<TJVMK, Java.Lang.Long> setStore)
             {
-                setStore.SetStore(mat.Cast<Org.Apache.Kafka.Streams.Kstream.Materialized<TJVMK, Java.Lang.Long, Org.Apache.Kafka.Streams.State.KeyValueStore<Org.Apache.Kafka.Common.Utils.Bytes, byte[]>>>());
+                setStore.SetStore(mat.CastDirectAndDetach<Org.Apache.Kafka.Streams.Kstream.Materialized<TJVMK, Java.Lang.Long, Org.Apache.Kafka.Streams.State.KeyValueStore<Org.Apache.Kafka.Common.Utils.Bytes, byte[]>>>());
             }
             return cont;
         }
@@ -80,7 +80,7 @@ namespace MASES.KNet.Streams.Kstream
             Materialized<K, V, TJVMK, TJVMV> cont = new();
             if (cont is IKNetMaterialized<TJVMK, TJVMV> setStore)
             {
-                setStore.SetStore(mat.Cast<Org.Apache.Kafka.Streams.Kstream.Materialized<TJVMK, TJVMV, Org.Apache.Kafka.Streams.State.KeyValueStore<Org.Apache.Kafka.Common.Utils.Bytes, byte[]>>>());
+                setStore.SetStore(mat.CastDirectAndDetach<Org.Apache.Kafka.Streams.Kstream.Materialized<TJVMK, TJVMV, Org.Apache.Kafka.Streams.State.KeyValueStore<Org.Apache.Kafka.Common.Utils.Bytes, byte[]>>>());
             }
             return cont;
         }
@@ -225,7 +225,7 @@ namespace MASES.KNet.Streams.Kstream
             TContainer cont = new();
             if (cont is IKNetMaterialized<TJVMK, TJVMV> setStore)
             {
-                setStore.SetStore(mat.Cast<Org.Apache.Kafka.Streams.Kstream.Materialized<TJVMK, TJVMV, Org.Apache.Kafka.Streams.State.KeyValueStore<Org.Apache.Kafka.Common.Utils.Bytes, byte[]>>>());
+                setStore.SetStore(mat.CastDirectAndDetach<Org.Apache.Kafka.Streams.Kstream.Materialized<TJVMK, TJVMV, Org.Apache.Kafka.Streams.State.KeyValueStore<Org.Apache.Kafka.Common.Utils.Bytes, byte[]>>>());
             }
             return cont;
         }
@@ -240,7 +240,7 @@ namespace MASES.KNet.Streams.Kstream
             TContainer cont = new();
             if (cont is IKNetMaterialized<TJVMK, TJVMV> setStore)
             {
-                setStore.SetStore(mat.Cast<Org.Apache.Kafka.Streams.Kstream.Materialized<TJVMK, TJVMV, Org.Apache.Kafka.Streams.State.KeyValueStore<Org.Apache.Kafka.Common.Utils.Bytes, byte[]>>>());
+                setStore.SetStore(mat.CastDirectAndDetach<Org.Apache.Kafka.Streams.Kstream.Materialized<TJVMK, TJVMV, Org.Apache.Kafka.Streams.State.KeyValueStore<Org.Apache.Kafka.Common.Utils.Bytes, byte[]>>>());
             }
             return cont;
         }

--- a/src/net/KNet/Specific/Streams/Processor/TimestampExtractor.cs
+++ b/src/net/KNet/Specific/Streams/Processor/TimestampExtractor.cs
@@ -57,7 +57,7 @@ namespace MASES.KNet.Streams.Processor
         {
             _keySerializer ??= _factory?.BuildKeySerDes<K, TJVMK>();
             _valueSerializer ??= _factory?.BuildValueSerDes<V, TJVMV>();
-            var record = arg0.Cast<Org.Apache.Kafka.Clients.Consumer.ConsumerRecord<TJVMK, TJVMV>>(); // KNet consider the data within Apache Kafka Streams defined always as byte[]
+            var record = arg0.CastDirectAndDetach<Org.Apache.Kafka.Clients.Consumer.ConsumerRecord<TJVMK, TJVMV>>(); // KNet consider the data within Apache Kafka Streams defined always as byte[]
 
             _record = new ConsumerRecord<K, V, TJVMK, TJVMV>(record, _factory);
             _partitionTime = (arg1 == -1) ? null : DateTimeOffset.FromUnixTimeMilliseconds(arg1).DateTime;

--- a/src/net/templates/templates/knetConnectSink/KNetConnectSink.cs
+++ b/src/net/templates/templates/knetConnectSink/KNetConnectSink.cs
@@ -37,7 +37,7 @@ namespace MASES.KNet.Template.KNetConnect
         public override void Put(IEnumerable<SinkRecord> collection)
         {
             // receives the records from Apache Kafka Connect to be used from connector
-            var castedValues = collection.CastTo<string>();
+            var castedValues = collection.CastDirectAndDetach<string>();
 
             foreach (var item in castedValues)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add CastDirectAndDetach extension overloads for IEnumerable<SinkRecord> to perform direct cast-and-detach operations. Replace existing CastTo usages with CastDirectAndDetach across Connect transforms and predicates, SerDes selection, KStream Materialized helpers, TimestampExtractor, and the KNetConnectSink template so objects are cast and detached consistently (source cannot be used after detaching). This centralizes the direct cast behavior and updates call sites accordingly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
