### PR TITLE
Use AddVoid, JVMBridge.New and dispose patterns

### DIFF
--- a/src/net/KNet.Serialization.Avro/AvroSerDes.cs
+++ b/src/net/KNet.Serialization.Avro/AvroSerDes.cs
@@ -166,8 +166,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(string, Headers, T)"/>
                     public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                        headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                        headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                        headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                         if (data == null) return null;
 
@@ -179,8 +179,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, T)"/>
                     public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                        headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                        headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                        headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                         if (data == null) return null;
 
@@ -272,8 +272,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(string, Headers, T)"/>
                     public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                        headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                        headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                        headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                         if (data == null) return null;
 
@@ -285,8 +285,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, T)"/>
                     public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                        headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                        headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                        headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                         if (data == null) return null;
 
@@ -424,8 +424,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(string, Headers, T)"/>
                     public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                        headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                        headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                        headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                         if (data == null) return null;
 
@@ -437,8 +437,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, T)"/>
                     public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                        headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                        headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                        headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                         if (data == null) return null;
 
@@ -530,8 +530,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(string, Headers, T)"/>
                     public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                        headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                        headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                        headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                         if (data == null) return null;
 
@@ -543,8 +543,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, T)"/>
                     public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                        headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                        headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                        headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                         if (data == null) return null;
 
@@ -689,8 +689,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(string, Headers, T)"/>
                     public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                        headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                        headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                        headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                         if (data == null) return null;
 
@@ -702,8 +702,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, T)"/>
                     public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                        headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                        headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                        headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                         if (data == null) return null;
 
@@ -795,8 +795,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(string, Headers, T)"/>
                     public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                        headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                        headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                        headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                         if (data == null) return null;
 
@@ -808,8 +808,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, T)"/>
                     public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                        headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                        headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                        headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                         if (data == null) return null;
 
@@ -948,8 +948,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(string, Headers, T)"/>
                     public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                        headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                        headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                        headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                         if (data == null) return null;
 
@@ -961,8 +961,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, T)"/>
                     public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                        headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                        headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                        headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                         if (data == null) return null;
 
@@ -1054,8 +1054,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(string, Headers, T)"/>
                     public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                        headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                        headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                        headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                         if (data == null) return null;
 
@@ -1067,8 +1067,8 @@ namespace MASES.KNet.Serialization.Avro
                     /// <inheritdoc cref="SerDes{T, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, T)"/>
                     public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                     {
-                        headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                        headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                        headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                        headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                         if (data == null) return null;
 

--- a/src/net/KNet.Serialization.Json/JsonSerDes.cs
+++ b/src/net/KNet.Serialization.Json/JsonSerDes.cs
@@ -127,8 +127,8 @@ namespace MASES.KNet.Serialization.Json
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (_defaultSerDes != null) return _defaultSerDes.SerializeWithHeaders(topic, headers, data);
                     if (data == null) return null;
@@ -143,8 +143,8 @@ namespace MASES.KNet.Serialization.Json
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (_defaultSerDes != null) return _defaultSerDes.SerializeWithHeaders(topic, headers, data);
                     if (data == null) return null;
@@ -256,8 +256,8 @@ namespace MASES.KNet.Serialization.Json
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (_defaultSerDes != null) return _defaultSerDes.SerializeWithHeaders(topic, headers, data);
                     if (data == null) return null;
@@ -286,8 +286,8 @@ namespace MASES.KNet.Serialization.Json
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (_defaultSerDes != null) return _defaultSerDes.SerializeWithHeaders(topic, headers, data);
                     if (data == null) return null;
@@ -472,8 +472,8 @@ namespace MASES.KNet.Serialization.Json
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (_defaultSerDes != null) return _defaultSerDes.SerializeWithHeaders(topic, headers, data);
                     if (data == null) return null;
@@ -488,8 +488,8 @@ namespace MASES.KNet.Serialization.Json
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (_defaultSerDes != null) return _defaultSerDes.SerializeWithHeaders(topic, headers, data);
                     if (data == null) return null;
@@ -602,8 +602,8 @@ namespace MASES.KNet.Serialization.Json
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (_defaultSerDes != null) return _defaultSerDes.SerializeWithHeaders(topic, headers, data);
                     if (data == null) return null;
@@ -632,8 +632,8 @@ namespace MASES.KNet.Serialization.Json
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (_defaultSerDes != null) return _defaultSerDes.SerializeWithHeaders(topic, headers, data);
                     if (data == null) return null;

--- a/src/net/KNet.Serialization.MessagePack/MessagePackSerDes.cs
+++ b/src/net/KNet.Serialization.MessagePack/MessagePackSerDes.cs
@@ -109,8 +109,8 @@ namespace MASES.KNet.Serialization.MessagePack
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (data == null) return null;
 
@@ -119,8 +119,8 @@ namespace MASES.KNet.Serialization.MessagePack
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (data == null) return null;
 
@@ -194,8 +194,8 @@ namespace MASES.KNet.Serialization.MessagePack
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (data == null) return null;
 
@@ -206,8 +206,8 @@ namespace MASES.KNet.Serialization.MessagePack
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (data == null) return null;
 
@@ -327,8 +327,8 @@ namespace MASES.KNet.Serialization.MessagePack
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (data == null) return null;
 
@@ -337,8 +337,8 @@ namespace MASES.KNet.Serialization.MessagePack
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (data == null) return null;
 
@@ -412,8 +412,8 @@ namespace MASES.KNet.Serialization.MessagePack
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (data == null) return null;
 
@@ -424,8 +424,8 @@ namespace MASES.KNet.Serialization.MessagePack
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (data == null) return null;
 

--- a/src/net/KNet.Serialization.Protobuf/ProtobufSerDes.cs
+++ b/src/net/KNet.Serialization.Protobuf/ProtobufSerDes.cs
@@ -103,8 +103,8 @@ namespace MASES.KNet.Serialization.Protobuf
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (data == null) return null;
 
@@ -117,8 +117,8 @@ namespace MASES.KNet.Serialization.Protobuf
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (data == null) return null;
 
@@ -183,8 +183,8 @@ namespace MASES.KNet.Serialization.Protobuf
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (data == null) return null;
 
@@ -197,8 +197,8 @@ namespace MASES.KNet.Serialization.Protobuf
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
-                    headers?.Add(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
+                    headers?.AddVoid(KNetSerialization.KeyTypeIdentifierJVM, keyTypeName);
+                    headers?.AddVoid(KNetSerialization.KeySerializerIdentifierJVM, keySerDesName);
 
                     if (data == null) return null;
 
@@ -321,8 +321,8 @@ namespace MASES.KNet.Serialization.Protobuf
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (data == null) return null;
 
@@ -335,8 +335,8 @@ namespace MASES.KNet.Serialization.Protobuf
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override byte[] SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (data == null) return null;
 
@@ -401,8 +401,8 @@ namespace MASES.KNet.Serialization.Protobuf
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(string, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(string topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (data == null) return null;
 
@@ -415,8 +415,8 @@ namespace MASES.KNet.Serialization.Protobuf
                 /// <inheritdoc cref="SerDes{TData, TJVMT}.SerializeWithHeaders(Java.Lang.String, Headers, TData)"/>
                 public override Java.Nio.ByteBuffer SerializeWithHeaders(Java.Lang.String topic, Headers headers, TData data)
                 {
-                    headers?.Add(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
-                    headers?.Add(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
+                    headers?.AddVoid(KNetSerialization.ValueSerializerIdentifierJVM, valueSerDesName);
+                    headers?.AddVoid(KNetSerialization.ValueTypeIdentifierJVM, valueTypeName);
 
                     if (data == null) return null;
 

--- a/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
@@ -285,7 +285,7 @@ namespace Org.Apache.Kafka.Clients.Admin
                                     var partitionIndex = partition.Partition();
                                     using TopicPartition topicPartition = new(topicName, partitionIndex);
                                     using var offsetSpec = OffsetSpec.Latest();
-                                    hashMap.Put(topicPartition, offsetSpec);
+                                    using var _ = hashMap.Put(topicPartition, offsetSpec);
                                 }
                             }
 

--- a/src/net/KNet/Developed/Org/Apache/Kafka/Common/Header/Headers.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Common/Header/Headers.cs
@@ -44,5 +44,34 @@ namespace Org.Apache.Kafka.Common.Header
         {
             return NewAndWrapsDirect<Headers>("org.apache.kafka.common.header.internals.RecordHeaders", headers);
         }
+
+        /// <summary>
+        /// <see langword="void"/> version of <see cref="Add(String, byte[])"/>
+        /// </summary>
+        /// <param name="arg0"><see cref="Java.Lang.String"/></param>
+        /// <param name="arg1"><see cref="byte"/></param>
+        /// <exception cref="Java.Lang.IllegalStateException"/>
+        public void AddVoid(Java.Lang.String arg0, byte[] arg1)
+        {
+            using var _ = Add(arg0, arg1);
+        }
+        /// <summary>
+        /// <see langword="void"/> version of <see cref="Add(Header)"/>
+        /// </summary>
+        /// <param name="arg0"><see cref="Org.Apache.Kafka.Common.Header.Header"/></param>
+        /// <exception cref="Java.Lang.IllegalStateException"/>
+        public void AddVoid(Org.Apache.Kafka.Common.Header.Header arg0)
+        {
+            using var _ = Add(arg0);
+        }
+        /// <summary>
+        /// <see langword="void"/> version of <see cref="Remove(String)"/>
+        /// </summary>
+        /// <param name="arg0"><see cref="Java.Lang.String"/></param>
+        /// <exception cref="Java.Lang.IllegalStateException"/>
+        public void RemoveVoid(Java.Lang.String arg0)
+        {
+            using var _ = Remove(arg0);
+        }
     }
 }

--- a/src/net/KNet/Specific/Connect/KNetConnector.cs
+++ b/src/net/KNet/Specific/Connect/KNetConnector.cs
@@ -235,7 +235,7 @@ namespace MASES.KNet.Connect
             {
                 using Java.Lang.String key = item.Key;
                 using Java.Lang.String value = item.Value;
-                props.Put(key, value);
+                using var _ = props.Put(key, value);
             }
             return retVal;
         }

--- a/src/net/KNet/Specific/Consumer/KNetConsumer.cs
+++ b/src/net/KNet/Specific/Consumer/KNetConsumer.cs
@@ -177,13 +177,13 @@ namespace MASES.KNet.Consumer
         {
             if (!props.ContainsKey(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
             {
-                props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.JVMDeserializerClassName);
+                using var _ = props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.JVMDeserializerClassName) as IDisposable;
             }
             else throw new InvalidOperationException($"KNetConsumer auto manages configuration property {Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG}, remove from configuration.");
 
             if (!props.ContainsKey(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
             {
-                props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.JVMDeserializerClassName);
+                using var _ = props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.JVMDeserializerClassName) as IDisposable;
             }
             else throw new InvalidOperationException($"KNetConsumer auto manages configuration property {Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG}, remove from configuration.");
 

--- a/src/net/KNet/Specific/GenericConfigBuilder.cs
+++ b/src/net/KNet/Specific/GenericConfigBuilder.cs
@@ -125,10 +125,10 @@ namespace MASES.KNet
         /// <returns><see cref="Properties"/> containing the properties</returns>
         public Properties ToProperties()
         {
-            Properties props = new();
+            Properties props = JVMBridgeBase.New<Properties>();
             foreach (var item in _options)
             {
-                props.Put(item.Key, item.Value);
+                using var _ = props.Put(item.Key, item.Value) as IDisposable;
             }
 
             return props;
@@ -140,10 +140,10 @@ namespace MASES.KNet
         /// <returns><see cref="Map{String, String}"/> containing the properties</returns>
         public Map<Java.Lang.String, Java.Lang.String> ToMap()
         {
-            HashMap<Java.Lang.String, Java.Lang.String> props = new();
+            HashMap<Java.Lang.String, Java.Lang.String> props = JVMBridgeBase.New<HashMap<Java.Lang.String, Java.Lang.String>>();
             foreach (var item in _options)
             {
-                props.Put(item.Key, Convert.ToString(item.Value, CultureInfo.InvariantCulture));
+                using var _ = props.Put(item.Key, Convert.ToString(item.Value, CultureInfo.InvariantCulture));
             }
 
             return props;

--- a/src/net/KNet/Specific/KNetConfigurationFromMap.cs
+++ b/src/net/KNet/Specific/KNetConfigurationFromMap.cs
@@ -396,7 +396,7 @@ namespace MASES.KNet
                     using (item)
                     {
                         using var key = item.Key;
-                        yield return new KeyValuePair<string, object>(key, item.Value);
+                        yield return new KeyValuePair<string, object>(key.ToString(), item.Value);
                     }
                 }
             }
@@ -408,7 +408,7 @@ namespace MASES.KNet
                     using (item)
                     {
                         using var key = item.Key;
-                        yield return new KeyValuePair<string, object>(key, item.Value);
+                        yield return new KeyValuePair<string, object>(key.ToString(), item.Value);
                     }
                 }
             }

--- a/src/net/KNet/Specific/Producer/KNetProducer.cs
+++ b/src/net/KNet/Specific/Producer/KNetProducer.cs
@@ -248,13 +248,13 @@ namespace MASES.KNet.Producer
         {
             if (!props.ContainsKey(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG))
             {
-                props.Put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer.JVMSerializerClassName);
+                using var _ = props.Put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer.JVMSerializerClassName) as IDisposable;
             }
             else throw new InvalidOperationException($"KNetProducer auto manages configuration property {ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG}, remove from configuration.");
 
             if (!props.ContainsKey(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG))
             {
-                props.Put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer.JVMSerializerClassName);
+                using var _ = props.Put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer.JVMSerializerClassName) as IDisposable;
             }
             else throw new InvalidOperationException($"KNetProducer auto manages configuration property {ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG}, remove from configuration.");
 
@@ -295,7 +295,7 @@ namespace MASES.KNet.Producer
             using IDisposable disposableValue = jVMV as IDisposable;
             try
             {
-                return new Org.Apache.Kafka.Clients.Producer.ProducerRecord<TJVMK, TJVMV>(topic, partition, timestamp, jVMK, jVMV, headers);
+                return JVMBridgeBase.New<Org.Apache.Kafka.Clients.Producer.ProducerRecord<TJVMK, TJVMV>>(topic, partition, timestamp, jVMK, jVMV, headers);
             }
             finally
             {

--- a/src/net/KNet/Specific/Replicator/KNetCompactedReplicator.cs
+++ b/src/net/KNet/Specific/Replicator/KNetCompactedReplicator.cs
@@ -448,7 +448,7 @@ namespace MASES.KNet.Replicator
             static void OnDemandRetrieve(IConsumer<K, V, TJVMK, TJVMV> consumer, string topic, K key, ILocalDataStorage data)
             {
                 using var scope = new JCOBridgeDisposeFastScope();
-                using var topicPartition = new Org.Apache.Kafka.Common.TopicPartition(topic, data.Partition);
+                using var topicPartition = JVMBridgeBase.New<Org.Apache.Kafka.Common.TopicPartition>(topic, data.Partition);
                 using var topics = Java.Util.Collections.Singleton(topicPartition);
                 consumer.Assign(topics);
                 consumer.Seek(topicPartition, data.Offset);

--- a/src/net/KNet/Specific/Streams/KNetClientSupplier.cs
+++ b/src/net/KNet/Specific/Streams/KNetClientSupplier.cs
@@ -17,6 +17,7 @@
 */
 
 using Java.Util;
+using MASES.JCOBridge.C2JBridge;
 using MASES.KNet.Consumer;
 using MASES.KNet.Producer;
 using System.Threading;
@@ -49,7 +50,7 @@ namespace MASES.KNet.Streams
         /// <inheritdoc/>
         public override Org.Apache.Kafka.Clients.Consumer.Consumer<byte[], byte[]> GetConsumer(Map<Java.Lang.String, object> arg0)
         {
-            Properties properties = new();
+            Properties properties = JVMBridgeBase.New<Properties>();
             properties.PutAll(arg0);
 
             var consumer = new KNetConsumer<byte[], byte[], byte[], byte[]>(properties);
@@ -59,7 +60,7 @@ namespace MASES.KNet.Streams
         /// <inheritdoc/>
         public override Org.Apache.Kafka.Clients.Consumer.Consumer<byte[], byte[]> GetGlobalConsumer(Map<Java.Lang.String, object> arg0)
         {
-            Properties properties = new();
+            Properties properties = JVMBridgeBase.New<Properties>();
             properties.PutAll(arg0);
 
             var consumer = new KNetConsumer<byte[], byte[], byte[], byte[]>(properties);
@@ -69,7 +70,7 @@ namespace MASES.KNet.Streams
         /// <inheritdoc/>
         public override Org.Apache.Kafka.Clients.Producer.Producer<byte[], byte[]> GetProducer(Map<Java.Lang.String, object> arg0)
         {
-            Properties properties = new();
+            Properties properties = JVMBridgeBase.New<Properties>();
             properties.PutAll(arg0);
 
             var producer = new KNetProducer<byte[], byte[], byte[], byte[]>(properties);
@@ -79,7 +80,7 @@ namespace MASES.KNet.Streams
         /// <inheritdoc/>
         public override Org.Apache.Kafka.Clients.Consumer.Consumer<byte[], byte[]> GetRestoreConsumer(Map<Java.Lang.String, object> arg0)
         {
-            Properties properties = new();
+            Properties properties = JVMBridgeBase.New<Properties>();
             properties.PutAll(arg0);
 
             var consumer = new KNetConsumer<byte[], byte[], byte[], byte[]>(properties);

--- a/src/net/KNet/Specific/Streams/KNetStreams.cs
+++ b/src/net/KNet/Specific/Streams/KNetStreams.cs
@@ -17,6 +17,8 @@
 */
 
 using Java.Time;
+using Java.Util;
+using MASES.JCOBridge.C2JBridge;
 using MASES.KNet.Serialization;
 using MASES.KNet.Streams.Processor;
 using MASES.KNet.Streams.State;
@@ -51,7 +53,7 @@ namespace MASES.KNet.Streams
         public KNetStreams(Topology arg0, StreamsConfigBuilder arg1, Org.Apache.Kafka.Common.Utils.Time arg2)
         {
             _properties = PrepareProperties(arg1);
-            _inner = new Org.Apache.Kafka.Streams.KafkaStreams(arg0, _properties, arg2);
+            _inner = JVMBridgeBase.New<Org.Apache.Kafka.Streams.KafkaStreams>(arg0, _properties, arg2);
             _factory = arg1;
         }
         /// <summary>
@@ -64,7 +66,7 @@ namespace MASES.KNet.Streams
         public KNetStreams(Topology arg0, StreamsConfigBuilder arg1, KNetClientSupplier arg2, Org.Apache.Kafka.Common.Utils.Time arg3)
         {
             _properties = PrepareProperties(arg1);
-            _inner = new Org.Apache.Kafka.Streams.KafkaStreams(arg0, _properties, arg2, arg3);
+            _inner = JVMBridgeBase.New<Org.Apache.Kafka.Streams.KafkaStreams>(arg0, _properties, arg2, arg3);
             _factory = arg1;
             _supplier = arg2;
         }
@@ -77,7 +79,7 @@ namespace MASES.KNet.Streams
         public KNetStreams(Topology arg0, StreamsConfigBuilder arg1, KNetClientSupplier arg2)
         {
             _properties = PrepareProperties(arg1);
-            _inner = new Org.Apache.Kafka.Streams.KafkaStreams(arg0, _properties, arg2);
+            _inner = JVMBridgeBase.New<Org.Apache.Kafka.Streams.KafkaStreams>(arg0, _properties, arg2);
             _factory = arg1;
             _supplier = arg2;
         }
@@ -89,7 +91,7 @@ namespace MASES.KNet.Streams
         public KNetStreams(Topology arg0, StreamsConfigBuilder arg1)
         {
             _properties = PrepareProperties(arg1);
-            _inner = new Org.Apache.Kafka.Streams.KafkaStreams(arg0, _properties);
+            _inner = JVMBridgeBase.New<Org.Apache.Kafka.Streams.KafkaStreams>(arg0, _properties);
             _factory = arg1;
         }
         #endregion

--- a/src/net/KNet/Specific/Streams/KeyValueSupport.cs
+++ b/src/net/KNet/Specific/Streams/KeyValueSupport.cs
@@ -36,23 +36,26 @@ namespace MASES.KNet.Streams
         /// Default constructor: even if the corresponding Java class does not have one, it is mandatory for JCOBridge
         /// </summary>
         public KeyValueSupport() { }
-        /// <summary>
-        /// Initialize a new instance of <see cref="KeyValueSupport{K, V}"/> from an instance of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/3.9.2/org/apache/kafka/streams/KeyValue.html#org.apache.kafka.streams.KeyValue(java.lang.Object,java.lang.Object)"/>
-        /// </summary>
-        /// <param name="obj">The <see cref="IJavaObject"/> referring <see cref="Org.Apache.Kafka.Streams.KeyValue{K, V}"/></param>
-        public KeyValueSupport(Org.Apache.Kafka.Streams.KeyValue<K,V> obj) : this(obj.BridgeInstance)
-        {
-        }
-        /// <summary>
-        /// Initialize a new instance of <see cref="KeyValueSupport{K, V}"/> from an instance of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/3.9.2/org/apache/kafka/streams/KeyValue.html#org.apache.kafka.streams.KeyValue(java.lang.Object,java.lang.Object)"/>
-        /// </summary>
-        /// <param name="obj">The <see cref="IJavaObject"/> referring <see cref="Org.Apache.Kafka.Streams.KeyValue{K, V}"/></param>
-        public KeyValueSupport(IJavaObject obj) : base(obj)
-        {
-            _inner = obj;
-        }
 
         #endregion
+        /// <summary>
+        /// Initialize a new instance of <see cref="KeyValueSupport{K, V}"/> from an instance of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/3.9.2/org/apache/kafka/streams/KeyValue.html#org.apache.kafka.streams.KeyValue(java.lang.Object,java.lang.Object)"/>
+        /// </summary>
+        /// <param name="obj">The <see cref="IJavaObject"/> referring <see cref="Org.Apache.Kafka.Streams.KeyValue{K, V}"/></param>
+        public static KeyValueSupport<K, V> Create(Org.Apache.Kafka.Streams.KeyValue<K, V> obj)
+        {
+            return Create(obj.BridgeInstance);
+        }
+        /// <summary>
+        /// Initialize a new instance of <see cref="KeyValueSupport{K, V}"/> from an instance of <see href="https://www.javadoc.io/doc/org.apache.kafka/kafka-streams/3.9.2/org/apache/kafka/streams/KeyValue.html#org.apache.kafka.streams.KeyValue(java.lang.Object,java.lang.Object)"/>
+        /// </summary>
+        /// <param name="obj">The <see cref="IJavaObject"/> referring <see cref="Org.Apache.Kafka.Streams.KeyValue{K, V}"/></param>
+        public static KeyValueSupport<K, V> Create(IJavaObject obj)
+        {
+            var result = MASES.JCOBridge.C2JBridge.JVMBridgeBase.New<KeyValueSupport<K, V>>(obj);
+            result._inner = obj;
+            return result;
+        }
 
         const string _bridgeClassName = "org.mases.knet.developed.streams.KeyValueSupport";
 

--- a/src/net/KNet/Specific/Streams/Kstream/KeyValueMapper.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/KeyValueMapper.cs
@@ -17,6 +17,7 @@
 */
 
 using Java.Util;
+using MASES.JCOBridge.C2JBridge;
 using MASES.KNet.Serialization;
 using System;
 using System.Collections.Generic;
@@ -228,7 +229,7 @@ namespace MASES.KNet.Streams.Kstream
 
             var methodToExecute = (OnApply != null) ? OnApply : Apply;
             var res = methodToExecute(_kSerializer.Deserialize((Java.Lang.String)null, arg0), _vSerializer.Deserialize((Java.Lang.String)null, arg1));
-            var result = new ArrayList<Org.Apache.Kafka.Streams.KeyValue<TJVMKR, TJVMVR>>();
+            var result = JVMBridgeBase.New<ArrayList<Org.Apache.Kafka.Streams.KeyValue<TJVMKR, TJVMVR>>>();
             foreach (var item in res)
             {
                 var jKR = _krSerializer.Serialize((Java.Lang.String)null, item.Item1);
@@ -236,7 +237,7 @@ namespace MASES.KNet.Streams.Kstream
 
                 using var disposable0 = jKR as IDisposable;
                 using var disposable1 = jVR as IDisposable;
-                using var data = new Org.Apache.Kafka.Streams.KeyValue<TJVMKR, TJVMVR>(jKR, jVR);
+                using var data = JVMBridgeBase.New<Org.Apache.Kafka.Streams.KeyValue<TJVMKR, TJVMVR>>(jKR, jVR);
                 result.Add(data);
             }
             return result;

--- a/src/net/KNet/Specific/Streams/Kstream/ValueMapper.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueMapper.cs
@@ -17,6 +17,7 @@
 */
 
 using Java.Util;
+using MASES.JCOBridge.C2JBridge;
 using MASES.KNet.Serialization;
 using System;
 using System.Collections.Generic;
@@ -126,7 +127,7 @@ namespace MASES.KNet.Streams.Kstream
 
             var methodToExecute = (OnApply != null) ? OnApply : Apply;
             var res = methodToExecute(_vSerializer.Deserialize((Java.Lang.String)null, arg0));
-            var result = new ArrayList<TJVMVR>();
+            var result = JVMBridgeBase.New<ArrayList<TJVMVR>>();
             foreach (var item in res)
             {
                 var localValue = _vrSerializer.Serialize((Java.Lang.String)null, item);

--- a/src/net/KNet/Specific/Streams/Kstream/ValueMapperWithKey.cs
+++ b/src/net/KNet/Specific/Streams/Kstream/ValueMapperWithKey.cs
@@ -159,7 +159,7 @@ namespace MASES.KNet.Streams.Kstream
 
             IEnumerable<VR> res = (OnApply != null) ? OnApply(this) : Apply();
             _vrSerializer ??= Factory?.BuildValueSerDes<VR, TJVMVR>();
-            var result = new ArrayList<TJVMVR>();
+            var result = JVMBridgeBase.New<ArrayList<TJVMVR>>();
             foreach (var item in res)
             {
                 var localValue = _vrSerializer.Serialize((Java.Lang.String)null, item);

--- a/src/net/KNet/Specific/Streams/Processor/StreamPartitioner.cs
+++ b/src/net/KNet/Specific/Streams/Processor/StreamPartitioner.cs
@@ -98,7 +98,7 @@ namespace MASES.KNet.Streams.Processor
             var res = (OnPartitions != null) ? OnPartitions(this) : Partitions();
             if (res == null || res.Count == 0) return Optional<Set<Integer>>.Empty();
             using var scope = new JCOBridgeDisposeFastScope();
-            using HashSet<Integer> result = new HashSet<Integer>();
+            using HashSet<Integer> result = JVMBridgeBase.New<HashSet<Integer>>();
             foreach (var item in res)
             {
                 if (item.HasValue)

--- a/src/net/KNet/Specific/Streams/Processor/StreamPartitionerNoValue.cs
+++ b/src/net/KNet/Specific/Streams/Processor/StreamPartitionerNoValue.cs
@@ -69,7 +69,7 @@ namespace MASES.KNet.Streams.Processor
             var res = methodToExecute(arg0, _kSerializer.Deserialize(arg0, arg1), arg3);
             if (res == null || res.Count == 0) return Optional<Set<Integer>>.Empty();
             using var scope = new JCOBridgeDisposeFastScope();
-            using HashSet<Integer> result = new HashSet<Integer>();
+            using HashSet<Integer> result = JVMBridgeBase.New<HashSet<Integer>>();
             foreach (var item in res)
             {
                 if (item.HasValue)

--- a/src/net/KNet/Specific/Streams/State/KeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/KeyValueIterator.cs
@@ -53,7 +53,7 @@ namespace MASES.KNet.Streams.State
                 if (input is IJavaObject obj)
                 {
                     return new KeyValue<K, V, TJVMK, TJVMV>(_factory,
-                                                            new KeyValueSupport<TJVMK, TJVMV>(obj),
+                                                            KeyValueSupport<TJVMK, TJVMV>.Create(obj),
                                                             keySerDes, valueSerDes, true);
                 }
                 throw new InvalidCastException($"input is not a valid IJavaObject");
@@ -101,7 +101,7 @@ namespace MASES.KNet.Streams.State
                 if (input is IJavaObject obj)
                 {
                     return new KeyValue<K, V, TJVMK, TJVMV>(_factory,
-                                                            new KeyValueSupport<TJVMK, TJVMV>(obj),
+                                                            KeyValueSupport<TJVMK, TJVMV>.Create(obj),
                                                             _keySerDes,
                                                             _valueSerDes,
                                                             false);
@@ -175,7 +175,7 @@ namespace MASES.KNet.Streams.State
             _keySerDes ??= factory?.BuildKeySerDes<K, TJVMK>();
             _valueSerDes ??= factory?.BuildValueSerDes<V, TJVMV>();
             var kv = _iterator.Next();
-            return new KeyValue<K, V, TJVMK, TJVMV>(factory, new KeyValueSupport<TJVMK, TJVMV>(kv), _keySerDes, _valueSerDes, false);
+            return new KeyValue<K, V, TJVMK, TJVMV>(factory, KeyValueSupport<TJVMK, TJVMV>.Create(kv), _keySerDes, _valueSerDes, false);
         }
         /// <summary>
         /// <see href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Iterator.html#remove()"/>

--- a/src/net/KNet/Specific/Streams/State/ManagedStore.cs
+++ b/src/net/KNet/Specific/Streams/State/ManagedStore.cs
@@ -76,6 +76,7 @@ namespace MASES.KNet.Streams.State
             {
                 disposable.Dispose();
             }
+            _store = default;
         }
     }
 }

--- a/src/net/KNet/Specific/Streams/State/TimestampedKeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/TimestampedKeyValueIterator.cs
@@ -52,7 +52,7 @@ namespace MASES.KNet.Streams.State
                 if (input is IJavaObject obj)
                 {
                     return new TimestampedKeyValue<K, V, TJVMK, TJVMV>(_factory,
-                                                                       new KeyValueSupport<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>(obj),
+                                                                       KeyValueSupport<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>.Create(obj),
                                                                        keySerDes, true);
                 }
                 throw new InvalidCastException($"input is not a valid IJavaObject");
@@ -96,7 +96,7 @@ namespace MASES.KNet.Streams.State
                 if (input is IJavaObject obj)
                 {
                     return new TimestampedKeyValue<K, V, TJVMK, TJVMV>(_factory,
-                                                                       new KeyValueSupport<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>(obj),
+                                                                       KeyValueSupport<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>.Create(obj),
                                                                        _keySerDes, false);
                 }
                 throw new InvalidCastException($"input is not a valid IJavaObject");
@@ -161,7 +161,7 @@ namespace MASES.KNet.Streams.State
             IGenericSerDesFactory factory = Factory;
             _keySerDes ??= factory?.BuildKeySerDes<K, TJVMK>();
             var kv = _iterator.Next();
-            return new TimestampedKeyValue<K, V, TJVMK, TJVMV>(factory, new KeyValueSupport<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>(kv), _keySerDes, false);
+            return new TimestampedKeyValue<K, V, TJVMK, TJVMV>(factory, KeyValueSupport<TJVMK, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>.Create(kv), _keySerDes, false);
         }
         /// <summary>
         /// <see href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Iterator.html#remove()"/>

--- a/src/net/KNet/Specific/Streams/State/TimestampedWindowedKeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/TimestampedWindowedKeyValueIterator.cs
@@ -51,7 +51,7 @@ namespace MASES.KNet.Streams.State
             {
                 if (input is IJavaObject obj)
                 {
-                    return new TimestampedWindowedKeyValue<K, V, TJVMK, TJVMV>(_factory, new KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>(obj));
+                    return new TimestampedWindowedKeyValue<K, V, TJVMK, TJVMV>(_factory, KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>.Create(obj));
                 }
                 throw new InvalidCastException($"input is not a valid IJavaObject");
             }
@@ -90,7 +90,7 @@ namespace MASES.KNet.Streams.State
             {
                 if (input is IJavaObject obj)
                 {
-                    return new TimestampedWindowedKeyValue<K, V, TJVMK, TJVMV>(_factory, new KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>(obj));
+                    return new TimestampedWindowedKeyValue<K, V, TJVMK, TJVMV>(_factory, KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>.Create(obj));
                 }
                 throw new InvalidCastException($"input is not a valid IJavaObject");
             }
@@ -150,7 +150,7 @@ namespace MASES.KNet.Streams.State
         public TimestampedWindowedKeyValue<K, V, TJVMK, TJVMV> Next()
         {
             var kv = _iterator.Next();
-            var kvs = new KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>(kv);
+            var kvs = KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, Org.Apache.Kafka.Streams.State.ValueAndTimestamp<TJVMV>>.Create(kv);
             return new TimestampedWindowedKeyValue<K, V, TJVMK, TJVMV>(Factory, kvs);
         }
         /// <summary>

--- a/src/net/KNet/Specific/Streams/State/WindowedKeyValueIterator.cs
+++ b/src/net/KNet/Specific/Streams/State/WindowedKeyValueIterator.cs
@@ -53,7 +53,7 @@ namespace MASES.KNet.Streams.State
                 if (input is IJavaObject obj)
                 {
                     return new WindowedKeyValue<K, V, TJVMK, TJVMV>(_factory,
-                                                                    new KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV>(obj),
+                                                                    KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV>.Create(obj),
                                                                     valueSerDes, true);
                 }
                 throw new InvalidCastException($"input is not a valid IJavaObject");
@@ -98,7 +98,7 @@ namespace MASES.KNet.Streams.State
                 if (input is IJavaObject obj)
                 {
                     return new WindowedKeyValue<K, V, TJVMK, TJVMV>(_factory,
-                                                                    new KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV>(obj),
+                                                                    KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV>.Create(obj),
                                                                     _valueSerDes, false);
                 }
                 throw new InvalidCastException($"input is not a valid IJavaObject");
@@ -163,7 +163,7 @@ namespace MASES.KNet.Streams.State
             IGenericSerDesFactory factory = Factory;
             _valueSerDes ??= factory?.BuildValueSerDes<V, TJVMV>();
             var kv = _iterator.Next();
-            return new WindowedKeyValue<K, V, TJVMK, TJVMV>(factory, new KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV>(kv), _valueSerDes, false);
+            return new WindowedKeyValue<K, V, TJVMK, TJVMV>(factory, KeyValueSupport<Org.Apache.Kafka.Streams.Kstream.Windowed<TJVMK>, TJVMV>.Create(kv), _valueSerDes, false);
         }
         /// <summary>
         /// <see href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Iterator.html#remove()"/>

--- a/src/net/KNet/Specific/Streams/Topology.cs
+++ b/src/net/KNet/Specific/Streams/Topology.cs
@@ -17,6 +17,7 @@
 */
 
 using Java.Util;
+using MASES.JCOBridge.C2JBridge;
 using MASES.JNet.Specific.Extensions;
 using MASES.KNet.Serialization;
 using MASES.KNet.Streams.Processor;
@@ -44,7 +45,7 @@ namespace MASES.KNet.Streams
         public Topology(TopologyConfig arg0)
         {
             if (arg0 is IGenericSerDesFactoryApplier applier) _factory = applier.Factory;
-            _topology = new Org.Apache.Kafka.Streams.Topology(arg0);
+            _topology = JVMBridgeBase.New<Org.Apache.Kafka.Streams.Topology>(arg0);
         }
 
         internal Topology(Org.Apache.Kafka.Streams.Topology topology, IGenericSerDesFactory factory)

--- a/src/net/KNet/Specific/Streams/TopologyConfig.cs
+++ b/src/net/KNet/Specific/Streams/TopologyConfig.cs
@@ -16,6 +16,7 @@
 *  Refer to LICENSE for more information.
 */
 
+using MASES.JCOBridge.C2JBridge;
 using MASES.KNet.Serialization;
 using System;
 
@@ -38,7 +39,7 @@ namespace MASES.KNet.Streams
         /// <param name="arg2"><see cref="Java.Util.Properties"/></param>
         public TopologyConfig(string arg0, StreamsConfigBuilder arg1, Java.Util.Properties arg2)
         {
-            _inner = new Org.Apache.Kafka.Streams.TopologyConfig(arg0, PrepareProperties(arg1), arg2);
+            _inner = JVMBridgeBase.New<Org.Apache.Kafka.Streams.TopologyConfig>(arg0, PrepareProperties(arg1), arg2);
             _factory = arg1;
         }
         /// <summary>
@@ -47,7 +48,7 @@ namespace MASES.KNet.Streams
         /// <param name="arg0"><see cref="StreamsConfigBuilder"/></param>
         public TopologyConfig(StreamsConfigBuilder arg0)
         {
-            _inner = new Org.Apache.Kafka.Streams.TopologyConfig(PrepareProperties(arg0));
+            _inner = JVMBridgeBase.New<Org.Apache.Kafka.Streams.TopologyConfig>(PrepareProperties(arg0));
             _factory = arg0;
         }
         #endregion
@@ -68,7 +69,7 @@ namespace MASES.KNet.Streams
         protected virtual Org.Apache.Kafka.Streams.StreamsConfig PrepareProperties(StreamsConfigBuilder builder)
         {
             Java.Util.Properties properties = OverrideProperties != null ? OverrideProperties(builder) : builder;
-            return new Org.Apache.Kafka.Streams.StreamsConfig(properties);
+            return JVMBridgeBase.New<Org.Apache.Kafka.Streams.StreamsConfig>(properties);
         }
 
         #region Fields


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Replace direct Headers.Add calls with AddVoid and add AddVoid/RemoveVoid helpers to Headers to consume IDisposable results without leaking. Adopt JVMBridgeBase.New for creating Java objects and wrap Put calls (and other methods returning disposables) with using to ensure proper disposal. Refactor KeyValueSupport to static Create factory and update callers, convert Java map keys to string in KNetConfigurationFromMap, and clear ManagedStore._store on dispose. Miscellaneous small fixes to avoid resource leaks when interacting with JVM bridge APIs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
