### PR TITLE
Use DisposeIfDisposable for returned objects

### DIFF
--- a/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
@@ -20,6 +20,7 @@ using Java.Time;
 using Java.Util;
 using Java.Util.Concurrent;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JNet.Specific.Extensions;
 using Org.Apache.Kafka.Clients.Consumer;
 using Org.Apache.Kafka.Common;
 using Org.Apache.Kafka.Common.Acl;
@@ -281,7 +282,7 @@ namespace Org.Apache.Kafka.Clients.Admin
                                     var partitionIndex = partition.Partition();
                                     using TopicPartition topicPartition = new(topicName, partitionIndex);
                                     using var offsetSpec = OffsetSpec.Latest();
-                                    using var _ = hashMap.Put(topicPartition, offsetSpec);
+                                    hashMap.Put(topicPartition, offsetSpec).DisposeIfDisposable();
                                 }
                             }
 

--- a/src/net/KNet/Developed/Org/Apache/Kafka/Common/Header/Headers.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Common/Header/Headers.cs
@@ -18,6 +18,7 @@
 
 using Java.Lang;
 using MASES.JCOBridge.C2JBridge.JVMInterop;
+using MASES.JNet.Specific.Extensions;
 
 namespace Org.Apache.Kafka.Common.Header
 {
@@ -53,7 +54,7 @@ namespace Org.Apache.Kafka.Common.Header
         /// <exception cref="Java.Lang.IllegalStateException"/>
         public void AddVoid(Java.Lang.String arg0, byte[] arg1)
         {
-            using var _ = Add(arg0, arg1);
+            Add(arg0, arg1).DisposeIfDisposable();
         }
         /// <summary>
         /// <see langword="void"/> version of <see cref="Add(Header)"/>
@@ -62,7 +63,7 @@ namespace Org.Apache.Kafka.Common.Header
         /// <exception cref="Java.Lang.IllegalStateException"/>
         public void AddVoid(Org.Apache.Kafka.Common.Header.Header arg0)
         {
-            using var _ = Add(arg0);
+            Add(arg0).DisposeIfDisposable();
         }
         /// <summary>
         /// <see langword="void"/> version of <see cref="Remove(String)"/>
@@ -71,7 +72,7 @@ namespace Org.Apache.Kafka.Common.Header
         /// <exception cref="Java.Lang.IllegalStateException"/>
         public void RemoveVoid(Java.Lang.String arg0)
         {
-            using var _ = Remove(arg0);
+            Remove(arg0).DisposeIfDisposable();
         }
     }
 }

--- a/src/net/KNet/Specific/Connect/KNetConnector.cs
+++ b/src/net/KNet/Specific/Connect/KNetConnector.cs
@@ -235,7 +235,7 @@ namespace MASES.KNet.Connect
             {
                 using Java.Lang.String key = item.Key;
                 using Java.Lang.String value = item.Value;
-                using var _ = props.Put(key, value);
+                props.Put(key, value).DisposeIfDisposable();
             }
             return retVal;
         }

--- a/src/net/KNet/Specific/Consumer/KNetConsumer.cs
+++ b/src/net/KNet/Specific/Consumer/KNetConsumer.cs
@@ -18,12 +18,13 @@
 
 using Java.Time;
 using Java.Util;
+using MASES.JCOBridge.C2JBridge;
+using MASES.JNet.Specific.Extensions;
+using MASES.KNet.Serialization;
+using Org.Apache.Kafka.Streams.Processor;
 using System;
 using System.Collections.Concurrent;
-using MASES.KNet.Serialization;
 using System.Threading;
-using MASES.JCOBridge.C2JBridge;
-using Org.Apache.Kafka.Streams.Processor;
 
 namespace MASES.KNet.Consumer
 {
@@ -177,13 +178,13 @@ namespace MASES.KNet.Consumer
         {
             if (!props.ContainsKey(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
             {
-                using var _ = props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.JVMDeserializerClassName) as IDisposable;
+                props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.JVMDeserializerClassName).DisposeIfDisposable();
             }
             else throw new InvalidOperationException($"KNetConsumer auto manages configuration property {Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG}, remove from configuration.");
 
             if (!props.ContainsKey(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
             {
-                using var _ = props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.JVMDeserializerClassName) as IDisposable;
+                props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.JVMDeserializerClassName).DisposeIfDisposable();
             }
             else throw new InvalidOperationException($"KNetConsumer auto manages configuration property {Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG}, remove from configuration.");
 

--- a/src/net/KNet/Specific/Consumer/KNetShareConsumer.cs
+++ b/src/net/KNet/Specific/Consumer/KNetShareConsumer.cs
@@ -19,6 +19,7 @@
 using Java.Time;
 using Java.Util;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JNet.Specific.Extensions;
 using MASES.KNet.Serialization;
 using System;
 using System.Collections.Concurrent;
@@ -170,13 +171,13 @@ namespace MASES.KNet.Consumer
         {
             if (!props.ContainsKey(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
             {
-                using var _ = props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.JVMDeserializerClassName) as IDisposable;
+                props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.JVMDeserializerClassName).DisposeIfDisposable();
             }
             else throw new InvalidOperationException($"KNetShareConsumer auto manages configuration property {Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG}, remove from configuration.");
 
             if (!props.ContainsKey(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
             {
-                using var _ = props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.JVMDeserializerClassName) as IDisposable;
+                props.Put(Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.JVMDeserializerClassName).DisposeIfDisposable();
             }
             else throw new InvalidOperationException($"KNetShareConsumer auto manages configuration property {Org.Apache.Kafka.Clients.Consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG}, remove from configuration.");
 

--- a/src/net/KNet/Specific/GenericConfigBuilder.cs
+++ b/src/net/KNet/Specific/GenericConfigBuilder.cs
@@ -17,14 +17,15 @@
 */
 
 using Java.Util;
-using System.Globalization;
-using System;
-using MASES.KNet.Serialization;
-using System.Linq;
-using System.Collections.Concurrent;
 using MASES.JCOBridge.C2JBridge;
-using System.Collections.Generic;
+using MASES.JNet.Specific.Extensions;
+using MASES.KNet.Serialization;
+using System;
 using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 
 namespace MASES.KNet
 {
@@ -128,7 +129,7 @@ namespace MASES.KNet
             Properties props = JVMBridgeBase.New<Properties>();
             foreach (var item in _options)
             {
-                using var _ = props.Put(item.Key, item.Value) as IDisposable;
+                props.Put(item.Key, item.Value).DisposeIfDisposable();
             }
 
             return props;
@@ -143,7 +144,7 @@ namespace MASES.KNet
             HashMap<Java.Lang.String, Java.Lang.String> props = JVMBridgeBase.New<HashMap<Java.Lang.String, Java.Lang.String>>();
             foreach (var item in _options)
             {
-                using var _ = props.Put(item.Key, Convert.ToString(item.Value, CultureInfo.InvariantCulture));
+                props.Put(item.Key, Convert.ToString(item.Value, CultureInfo.InvariantCulture)).DisposeIfDisposable();
             }
 
             return props;

--- a/src/net/KNet/Specific/Producer/KNetProducer.cs
+++ b/src/net/KNet/Specific/Producer/KNetProducer.cs
@@ -19,6 +19,7 @@
 using Java.Util;
 using Java.Util.Concurrent;
 using MASES.JCOBridge.C2JBridge;
+using MASES.JNet.Specific.Extensions;
 using MASES.KNet.Serialization;
 using Org.Apache.Kafka.Clients.Producer;
 using Org.Apache.Kafka.Common.Header;
@@ -248,13 +249,13 @@ namespace MASES.KNet.Producer
         {
             if (!props.ContainsKey(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG))
             {
-                using var _ = props.Put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer.JVMSerializerClassName) as IDisposable;
+                props.Put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer.JVMSerializerClassName).DisposeIfDisposable();
             }
             else throw new InvalidOperationException($"KNetProducer auto manages configuration property {ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG}, remove from configuration.");
 
             if (!props.ContainsKey(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG))
             {
-                using var _ = props.Put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer.JVMSerializerClassName) as IDisposable;
+                props.Put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer.JVMSerializerClassName).DisposeIfDisposable();
             }
             else throw new InvalidOperationException($"KNetProducer auto manages configuration property {ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG}, remove from configuration.");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Replace patterns like `using var _ = obj.Put(...)` with `obj.Put(...).DisposeIfDisposable()` across several KNet files and add the `MASES.JNet.Specific.Extensions` import where needed. Affected files: Admin.cs, Headers.cs, KNetConnector.cs, KNetConsumer.cs, KNetShareConsumer.cs, GenericConfigBuilder.cs, KNetProducer.cs. This unifies disposal handling for JNI/bridge-returned values, removes unused temporary variables and casts to IDisposable, and keeps using directives consistent.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
