### PR TITLE
Add partition offset methods for multiple OffsetSpecs

### DIFF
--- a/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
@@ -289,6 +289,14 @@ namespace Org.Apache.Kafka.Clients.Admin
         /// <param name="delta">A value to be added to each offset retrieved</param>
         /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the LatestTiered offset for each partition</returns>
         System.Collections.Generic.IDictionary<int, long> LatestTieredPartitionOffsetForTopic(string topicName, long delta = -1);
+        /// <summary>
+        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the Latest offset for each partition of the <paramref name="topicName"/>
+        /// </summary>
+        /// <param name="topicName">The topic to be queried</param>
+        /// <param name="delta">A value to be added to each offset retrieved</param>
+        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the Latest offset for each partition</returns>
+        [Obsolete("Use LatestTieredPartitionOffsetForTopic", true)]
+        System.Collections.Generic.IDictionary<int, long> LastPartitionOffsetForTopic(string topicName);
     }
 
     public partial class Admin
@@ -363,6 +371,14 @@ namespace Org.Apache.Kafka.Clients.Admin
         {
             using var offsetSpec = OffsetSpec.LatestTiered();
             return PartitionOffsetForTopic(topicName, offsetSpec, delta);
+        }
+
+        /// <inheritdoc/>
+        [Obsolete("Use LatestTieredPartitionOffsetForTopic", true)]
+        System.Collections.Generic.IDictionary<int, long> LastPartitionOffsetForTopic(string topicName)
+        {
+            using var offsetSpec = OffsetSpec.Latest();
+            return PartitionOffsetForTopic(topicName, offsetSpec, -1);
         }
 
         System.Collections.Generic.IDictionary<int, long> PartitionOffsetForTopic(string topicName, OffsetSpec offsetSpec, long delta)

--- a/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
@@ -26,6 +26,7 @@ using Org.Apache.Kafka.Common;
 using Org.Apache.Kafka.Common.Acl;
 using Org.Apache.Kafka.Common.Config;
 using Org.Apache.Kafka.Common.Quota;
+using System;
 
 namespace Org.Apache.Kafka.Clients.Admin
 {
@@ -231,11 +232,63 @@ namespace Org.Apache.Kafka.Clients.Admin
         /// <returns>The unique cluster id</returns>
         string GetClusterId();
         /// <summary>
-        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the last offset for each partition of the <paramref name="topicName"/>
+        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the ForTimestamp offset for each partition of the <paramref name="topicName"/>
         /// </summary>
         /// <param name="topicName">The topic to be queried</param>
-        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the last offset for each partition</returns>
-        System.Collections.Generic.IDictionary<int, long> LastPartitionOffsetForTopic(string topicName);
+        /// <param name="timestamp">The starting <see cref="DateTime"/></param>
+        /// <param name="delta">A value to be added to each offset retrieved</param>
+        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the ForTimestamp offset for each partition</returns>
+        System.Collections.Generic.IDictionary<int, long> ForTimestampPartitionOffsetForTopic(string topicName, DateTime timestamp, long delta = 0);
+        /// <summary>
+        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the ForTimestamp offset for each partition of the <paramref name="topicName"/>
+        /// </summary>
+        /// <param name="topicName">The topic to be queried</param>
+        /// <param name="timestamp">The starting Unix time in milliseconds</param>
+        /// <param name="delta">A value to be added to each offset retrieved</param>
+        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the ForTimestamp offset for each partition</returns>
+        System.Collections.Generic.IDictionary<int, long> ForTimestampPartitionOffsetForTopic(string topicName, long timestamp, long delta = 0);
+        /// <summary>
+        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the MaxTimestamp offset for each partition of the <paramref name="topicName"/>
+        /// </summary>
+        /// <param name="topicName">The topic to be queried</param>
+        /// <param name="delta">A value to be added to each offset retrieved</param>
+        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the MaxTimestamp offset for each partition</returns>
+        System.Collections.Generic.IDictionary<int, long> MaxTimestampPartitionOffsetForTopic(string topicName, long delta = 0);
+        /// <summary>
+        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the Earliest offset for each partition of the <paramref name="topicName"/>
+        /// </summary>
+        /// <param name="topicName">The topic to be queried</param>
+        /// <param name="delta">A value to be added to each offset retrieved</param>
+        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the Earliest offset for each partition</returns>
+        System.Collections.Generic.IDictionary<int, long> EarliestPartitionOffsetForTopic(string topicName, long delta = 0);
+        /// <summary>
+        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the EarliestLocal offset for each partition of the <paramref name="topicName"/>
+        /// </summary>
+        /// <param name="topicName">The topic to be queried</param>
+        /// <param name="delta">A value to be added to each offset retrieved</param>
+        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the EarliestLocal offset for each partition</returns>
+        System.Collections.Generic.IDictionary<int, long> EarliestLocalPartitionOffsetForTopic(string topicName, long delta = 0);
+        /// <summary>
+        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the EarliestPendingUpload offset for each partition of the <paramref name="topicName"/>
+        /// </summary>
+        /// <param name="topicName">The topic to be queried</param>
+        /// <param name="delta">A value to be added to each offset retrieved</param>
+        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the EarliestPendingUpload offset for each partition</returns>
+        System.Collections.Generic.IDictionary<int, long> EarliestPendingUploadPartitionOffsetForTopic(string topicName, long delta = 0);
+        /// <summary>
+        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the Latest offset for each partition of the <paramref name="topicName"/>
+        /// </summary>
+        /// <param name="topicName">The topic to be queried</param>
+        /// <param name="delta">A value to be added to each offset retrieved</param>
+        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the Latest offset for each partition</returns>
+        System.Collections.Generic.IDictionary<int, long> LatestPartitionOffsetForTopic(string topicName, long delta = -1);
+        /// <summary>
+        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the LatestTiered offset for each partition of the <paramref name="topicName"/>
+        /// </summary>
+        /// <param name="topicName">The topic to be queried</param>
+        /// <param name="delta">A value to be added to each offset retrieved</param>
+        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the LatestTiered offset for each partition</returns>
+        System.Collections.Generic.IDictionary<int, long> LatestTieredPartitionOffsetForTopic(string topicName, long delta = -1);
     }
 
     public partial class Admin
@@ -258,7 +311,61 @@ namespace Org.Apache.Kafka.Clients.Admin
         }
 
         /// <inheritdoc/>
-        public System.Collections.Generic.IDictionary<int, long> LastPartitionOffsetForTopic(string topicName)
+        public System.Collections.Generic.IDictionary<int, long> ForTimestampPartitionOffsetForTopic(string topicName, DateTime timestamp, long delta = 0)
+        {
+            return ForTimestampPartitionOffsetForTopic(topicName, new System.DateTimeOffset(timestamp).ToUnixTimeMilliseconds());
+        }
+
+        /// <inheritdoc/>
+        public System.Collections.Generic.IDictionary<int, long> ForTimestampPartitionOffsetForTopic(string topicName, long timestamp, long delta = 0)
+        {
+            using var offsetSpec = OffsetSpec.ForTimestamp(timestamp);
+            return PartitionOffsetForTopic(topicName, offsetSpec, delta);
+        }
+
+        /// <inheritdoc/>
+        public System.Collections.Generic.IDictionary<int, long> MaxTimestampPartitionOffsetForTopic(string topicName, long delta = 0)
+        {
+            using var offsetSpec = OffsetSpec.MaxTimestamp();
+            return PartitionOffsetForTopic(topicName, offsetSpec, delta);
+        }
+
+        /// <inheritdoc/>
+        public System.Collections.Generic.IDictionary<int, long> EarliestPartitionOffsetForTopic(string topicName, long delta = 0)
+        {
+            using var offsetSpec = OffsetSpec.Earliest();
+            return PartitionOffsetForTopic(topicName, offsetSpec, delta);
+        }
+
+        /// <inheritdoc/>
+        public System.Collections.Generic.IDictionary<int, long> EarliestLocalPartitionOffsetForTopic(string topicName, long delta = 0)
+        {
+            using var offsetSpec = OffsetSpec.EarliestLocal();
+            return PartitionOffsetForTopic(topicName, offsetSpec, delta);
+        }
+
+        /// <inheritdoc/>
+        public System.Collections.Generic.IDictionary<int, long> EarliestPendingUploadPartitionOffsetForTopic(string topicName, long delta = 0)
+        {
+            using var offsetSpec = OffsetSpec.EarliestPendingUpload();
+            return PartitionOffsetForTopic(topicName, offsetSpec, delta);
+        }
+
+        /// <inheritdoc/>
+        public System.Collections.Generic.IDictionary<int, long> LatestPartitionOffsetForTopic(string topicName, long delta = -1)
+        {
+            using var offsetSpec = OffsetSpec.Latest();
+            return PartitionOffsetForTopic(topicName, offsetSpec, delta);
+        }
+
+        /// <inheritdoc/>
+        public System.Collections.Generic.IDictionary<int, long> LatestTieredPartitionOffsetForTopic(string topicName, long delta = -1)
+        {
+            using var offsetSpec = OffsetSpec.LatestTiered();
+            return PartitionOffsetForTopic(topicName, offsetSpec, delta);
+        }
+
+        System.Collections.Generic.IDictionary<int, long> PartitionOffsetForTopic(string topicName, OffsetSpec offsetSpec, long delta)
         {
             System.Collections.Generic.Dictionary<int, long> dictionary = new();
             try
@@ -285,7 +392,6 @@ namespace Org.Apache.Kafka.Clients.Admin
                                 {
                                     var partitionIndex = partition.Partition();
                                     using TopicPartition topicPartition = new(topicName, partitionIndex);
-                                    using var offsetSpec = OffsetSpec.Latest();
                                     hashMap.Put(topicPartition, offsetSpec).DisposeIfDisposable();
                                 }
                             }
@@ -301,7 +407,7 @@ namespace Org.Apache.Kafka.Clients.Admin
                                 using var offsetResultItemTopic = offsetResultItemKey.Topic();
                                 if (offsetResultItemTopic.Equals(jTopic))
                                 {
-                                    dictionary.Add(offsetResultItemKey.Partition(), offsetResultItemValue.Offset() - 1); // since latest means the latest used offset (a record in kafka) + 1, here we remove 1 to be in sync with received offset from kafka
+                                    dictionary.Add(offsetResultItemKey.Partition(), offsetResultItemValue.Offset() + delta); // since latest means the latest used offset (a record in kafka) + 1, here we remove 1 to be in sync with received offset from kafka
                                 }
                             }
                             break;

--- a/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
@@ -269,13 +269,6 @@ namespace Org.Apache.Kafka.Clients.Admin
         /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the EarliestLocal offset for each partition</returns>
         System.Collections.Generic.IDictionary<int, long> EarliestLocalPartitionOffsetForTopic(string topicName, long delta = 0);
         /// <summary>
-        /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the EarliestPendingUpload offset for each partition of the <paramref name="topicName"/>
-        /// </summary>
-        /// <param name="topicName">The topic to be queried</param>
-        /// <param name="delta">A value to be added to each offset retrieved</param>
-        /// <returns>A <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the EarliestPendingUpload offset for each partition</returns>
-        System.Collections.Generic.IDictionary<int, long> EarliestPendingUploadPartitionOffsetForTopic(string topicName, long delta = 0);
-        /// <summary>
         /// Returns a <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/> containing the Latest offset for each partition of the <paramref name="topicName"/>
         /// </summary>
         /// <param name="topicName">The topic to be queried</param>
@@ -349,13 +342,6 @@ namespace Org.Apache.Kafka.Clients.Admin
         public System.Collections.Generic.IDictionary<int, long> EarliestLocalPartitionOffsetForTopic(string topicName, long delta = 0)
         {
             using var offsetSpec = OffsetSpec.EarliestLocal();
-            return PartitionOffsetForTopic(topicName, offsetSpec, delta);
-        }
-
-        /// <inheritdoc/>
-        public System.Collections.Generic.IDictionary<int, long> EarliestPendingUploadPartitionOffsetForTopic(string topicName, long delta = 0)
-        {
-            using var offsetSpec = OffsetSpec.EarliestPendingUpload();
             return PartitionOffsetForTopic(topicName, offsetSpec, delta);
         }
 

--- a/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
+++ b/src/net/KNet/Developed/Org/Apache/Kafka/Clients/Admin/Admin.cs
@@ -361,7 +361,7 @@ namespace Org.Apache.Kafka.Clients.Admin
 
         /// <inheritdoc/>
         [Obsolete("Use LatestTieredPartitionOffsetForTopic", true)]
-        System.Collections.Generic.IDictionary<int, long> LastPartitionOffsetForTopic(string topicName)
+        public System.Collections.Generic.IDictionary<int, long> LastPartitionOffsetForTopic(string topicName)
         {
             using var offsetSpec = OffsetSpec.Latest();
             return PartitionOffsetForTopic(topicName, offsetSpec, -1);

--- a/tests/net/General/KNetTest/Program.cs
+++ b/tests/net/General/KNetTest/Program.cs
@@ -313,7 +313,7 @@ namespace MASES.KNetTest
                 Console.WriteLine($"LastOffsetOfTopic for {topicName} using an AdminClient based on {props}");
 
                 using IAdmin admin = KafkaAdminClient.Create(props);
-                return admin.LastPartitionOffsetForTopic(topicName);
+                return admin.LatestPartitionOffsetForTopic(topicName);
             }
             catch (Java.Util.Concurrent.ExecutionException ex)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduce multiple partition-offset helpers: ForTimestampPartitionOffsetForTopic (DateTime and unix-ms), MaxTimestamp, Earliest, EarliestLocal, EarliestPendingUpload, Latest and LatestTiered. Refactor PartitionOffsetForTopic to accept an OffsetSpec and a delta adjustment (used to normalize latest offsets), and update offset computation accordingly. Also add System using. This replaces the prior LastPartitionOffsetForTopic with more explicit OffsetSpec-based methods and centralizes disposal/OffsetSpec handling.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
